### PR TITLE
Release v5.11.0: automated release process

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,14 +3,16 @@ name: Build and Test
 on:
   push:
     branches: [ main, dev ]
-    # Don't need to run on tags anymore, we always push artifacts to a draft release now.
-    # tags:
-    #   - 'v*'
+    tags:
+      - 'v*'
   # pull_request:
   #   branches: [ main, dev ]
 
 jobs:
   test-electron:
+    # Runs on every branch push AND every tag push. Packages with electron-builder
+    # so packaging failures are caught, but does NOT upload anywhere (--publish never).
+    # The separate `release` job below does the publishing on tag pushes only.
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -53,58 +55,33 @@ jobs:
         sleep 3
         npm run test:electron:ci
 
-    # - name: Test Electron app build (no packaging)
-    #   run: npx electron-builder --dir
-    #   env:
-    #     # Skip notarization and signing in PR builds
-    #     CSC_IDENTITY_AUTO_DISCOVERY: false
-
     #===============================================================
-    # NOTE: More build config is in package.json under the "build" key.
+    # Packaging smoke-test. Signing is intentionally skipped here so
+    # branch builds don't need secrets. The release job below does the
+    # signed build + publish on tag pushes.
     #===============================================================
-    - name: Build/release Electron app (Windows)
+    - name: Package Electron app (Windows)
       if: matrix.os == 'windows-latest'
-      # Publishes to a GitHub draft release if one exists for the current version,
-      # otherwise skips publishing (exit 0) — packaging is still tested either way.
-      run: npx electron-builder --win --publish onTagOrDraft
+      run: npx electron-builder --win --publish never
       env:
-        # Windows code signing
-        CSC_LINK: ${{ secrets.CSC_LINK }}
-        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        # Publish to GitHub Releases
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_IDENTITY_AUTO_DISCOVERY: false
 
-    - name: Build/release Electron app (Linux)
+    - name: Package Electron app (Linux)
       if: matrix.os == 'ubuntu-latest'
-      # Need to install noble dependencies for bluetooth support, see https://github.com/abandonware/noble#readme.
-      # Publishes to a GitHub draft release if one exists for the current version,
-      # otherwise skips publishing (exit 0) — packaging is still tested either way.
+      # Noble (Bluetooth) needs bluez dev headers on Ubuntu.
       run: |
         sudo apt install -y bluetooth bluez libbluetooth-dev libudev-dev
-        npx electron-builder --linux --publish onTagOrDraft
-      env:
-        # Publish to GitHub Releases
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        npx electron-builder --linux --publish never
 
-    - name: Build/release Electron app (Mac)
+    - name: Package Electron app (Mac)
       if: matrix.os == 'macos-15'
-      # Publishes to a GitHub draft release if one exists for the current version,
-      # otherwise skips publishing (exit 0) — packaging is still tested either way.
-      run: npx electron-builder --mac --publish onTagOrDraft
+      run: npx electron-builder --mac --publish never
       env:
-        # Publish to GitHub Releases
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # - name: Upload test results (Ubuntu only)
-    #   if: matrix.os == 'ubuntu-latest'
-    #   uses: actions/upload-artifact@v4
-    #   if: failure()
-    #   with:
-    #     name: playwright-report
-    #     path: playwright-report/
-    #     retention-days: 30
+        CSC_IDENTITY_AUTO_DISCOVERY: false
 
   release:
+    # Tag-push only. Builds signed artifacts on all three platforms and publishes
+    # them to a new GitHub Release via `electron-builder --publish always`.
     needs: test-electron
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
@@ -130,6 +107,10 @@ jobs:
       run: npm rebuild --build-from-source=false
       continue-on-error: true
 
+    - name: Verify app-data snapshot exists for current schema version
+      if: matrix.os == 'ubuntu-latest'
+      run: node scripts/check-appdata-snapshot.mjs
+
     - name: Build Electron app
       run: npm run build
 
@@ -148,7 +129,9 @@ jobs:
 
     - name: Build/release Electron app (Linux)
       if: matrix.os == 'ubuntu-latest'
-      run: npx electron-builder --linux --publish always
+      run: |
+        sudo apt install -y bluetooth bluez libbluetooth-dev libudev-dev
+        npx electron-builder --linux --publish always
       env:
         # Publish to GitHub Releases
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -159,3 +142,38 @@ jobs:
       env:
         # Publish to GitHub Releases
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-notes:
+    # Runs once, after all three platform builds in `release` have uploaded.
+    # Extracts the matching `## [X.Y.Z]` section from CHANGELOG.md and sets it
+    # as the GitHub Release body via `gh release edit`.
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v4
+
+    - name: Set release body from CHANGELOG
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        # Capture everything from the `## [VERSION]` heading up to (but not
+        # including) the next `## [...]` heading. `sed '$d'` drops that last
+        # matching line.
+        awk -v ver="$VERSION" '
+          /^## \[/ {
+            if (found) exit
+            if (index($0, "[" ver "]") > 0) { found=1; next }
+          }
+          found { print }
+        ' CHANGELOG.md | sed '/^$/N;/^\n$/D' > release-notes.md
+
+        if [ ! -s release-notes.md ]; then
+          echo "Could not extract CHANGELOG section for $VERSION; leaving release body untouched." >&2
+          exit 0
+        fi
+
+        gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- Release process is now fully automated from a single command: `npm run release <X.Y.Z>`. The script runs typecheck + unit tests + app-data-snapshot preflight, finalizes CHANGELOG (moves Unreleased into a dated section and adds the compare-link), bumps `package.json`, commits, tags, and pushes. CI takes over from there — builds and signs all three platforms, creates the GitHub Release with `electron-builder --publish always`, uploads artifacts, and extracts the matching `## [X.Y.Z]` section of CHANGELOG.md as the Release body via `gh release edit`. No more manual draft-release creation, no hand-pasted release notes. See the [Releasing section of the README](./README.md#releasing) for the full walkthrough.
+
 ## [5.10.0] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,19 +110,27 @@ Releases are fully automated from a single command. Prerequisites on release day
    - DevTools Console: `copy(localStorage.getItem('appData'))`.
    - Save clipboard to `local-storage-data/appData-v{N}-app-v{X.Y.Z}-default.json`.
 
-Then cut the release:
+Then cut the release. Always pass the full version explicitly — no `patch` /
+`minor` / `major` shortcuts, just one consistent form for stable, prerelease, or
+otherwise:
 
 ```
-npm run release patch   # bug-fix release (e.g. 5.10.0 → 5.10.1)
-npm run release minor   # new feature     (e.g. 5.10.0 → 5.11.0)
-npm run release major   # breaking change (e.g. 5.10.0 → 6.0.0)
-# or an explicit version:
-npm run release 5.11.0-rc.1
+npm run release 5.11.0         # next minor
+npm run release 5.10.1         # patch
+npm run release 5.11.0-rc.1    # prerelease
+npm run release v5.11.0        # v-prefix accepted too
 ```
+
+Choosing a number follows semver:
+
+- **Major** (`X.0.0`) — breaking changes. Examples from the README's history:
+  framework change, complete UI overhaul.
+- **Minor** (`5.X.0`) — new features added without breaking existing ones.
+- **Patch** (`5.10.X`) — bug fixes and small changes to existing functionality.
 
 The script runs typecheck + unit tests + the snapshot preflight, finalizes
 CHANGELOG (moves `Unreleased` into a dated section and adds the compare link),
-bumps `package.json`, commits `Release v{X.Y.Z}`, tags `v{X.Y.Z}`, and pushes
+writes `package.json`, commits `Release v{X.Y.Z}`, tags `v{X.Y.Z}`, and pushes
 `main` with the tag. Pass `--dry-run` to preview the changes without writing
 anything, or `--allow-dev` to release from the `dev` branch.
 

--- a/README.md
+++ b/README.md
@@ -100,19 +100,45 @@ Arduino sketches in `firmware-test-apps/arduino_*/` allow you to program differe
 
 ## Releasing
 
-1. Create a new branch off of `main` for the changes.
-1. Update the version number to the appropriate number in `package.json`. Major version number change for big changes (e.g. framework change or complete overhaul of UI). Minor version change when additional features have been added. Patch version change for bug fixes and small changes to existing functionality.
-1. On GitHub, manually create a **draft release** for the new version (e.g. `v4.2.0`) with no tag yet. This is required for the next step to work.
-1. Make changes to the code as required. Push commits to `dev` or `main` — CI will automatically upload build artifacts to the draft release (all three platforms) on each successful build.
-1. Update the CHANGELOG (don't forget the links right at the bottom of the page).
-1. If you have updated the app data structure, save a copy of the default app data created by the app to `local-storage-data/`. You can do this by running the app, clearing app data in `Settings > General Settings`, loading up the Chrome dev. tools, and copying the key `appData` from local storage.
-1. Create a pull request on GitHub merging your branch into `main` and merge it once CI passes.
-1. Push a version tag to `main`, e.g. `git tag v4.2.0 && git push origin v4.2.0`. This triggers the `release` CI job, which builds all three platforms and uploads the final artifacts to the draft release using `--publish always`.
-1. Find the draft release on GitHub, enter the CHANGELOG contents into the release body, and publish it.
+Releases are fully automated from a single command. Prerequisites on release day:
 
-**How CI publishing works:**
-- On every push to `main` or `dev`: CI builds and tests all three platforms. If a **draft release already exists** for the current version number, artifacts are uploaded to it (`--publish onTagOrDraft`). If no draft release exists, the build still runs but nothing is published.
-- On a `v*` tag push: CI first runs the full build and test suite (`test-electron` job), then the `release` job runs and publishes artifacts unconditionally (`--publish always`). Files in the draft release are overwritten.
+1. You're on `main` with a clean working tree, and the merge of the dev branch has landed.
+2. The CHANGELOG's `## Unreleased` section covers everything going out.
+3. If the app data schema (`LATEST_VERSION` in `src/renderer/src/model/AppDataManager/DataClasses/AppData.ts`) was bumped this cycle, save a fresh default snapshot:
+   - Run `npm run dev` and open the app.
+   - `Settings → General → Clear app data`.
+   - DevTools Console: `copy(localStorage.getItem('appData'))`.
+   - Save clipboard to `local-storage-data/appData-v{N}-app-v{X.Y.Z}-default.json`.
+
+Then cut the release:
+
+```
+npm run release patch   # bug-fix release (e.g. 5.10.0 → 5.10.1)
+npm run release minor   # new feature     (e.g. 5.10.0 → 5.11.0)
+npm run release major   # breaking change (e.g. 5.10.0 → 6.0.0)
+# or an explicit version:
+npm run release 5.11.0-rc.1
+```
+
+The script runs typecheck + unit tests + the snapshot preflight, finalizes
+CHANGELOG (moves `Unreleased` into a dated section and adds the compare link),
+bumps `package.json`, commits `Release v{X.Y.Z}`, tags `v{X.Y.Z}`, and pushes
+`main` with the tag. Pass `--dry-run` to preview the changes without writing
+anything, or `--allow-dev` to release from the `dev` branch.
+
+From there CI takes over: it builds and signs all three platforms, creates the
+GitHub Release, uploads the installers / updater manifests, and extracts the
+`## [X.Y.Z]` section from CHANGELOG.md as the Release body. There's no manual
+"create draft release" step any more.
+
+**How CI works:**
+- On every `main` / `dev` push: `test-electron` runs unit tests, the Electron
+  e2e suite (Ubuntu), and a packaging smoke-test on all three platforms with
+  `--publish never`. No upload.
+- On a `v*` tag push: `test-electron` runs first, then the `release` job
+  rebuilds all three platforms with signing + `electron-builder --publish always`,
+  which creates the GitHub Release and attaches the artifacts. A follow-up
+  `release-notes` job fills the Release body from CHANGELOG via `gh release edit`.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "dist:win": "npm run build && electron-builder --win",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:linux": "npm run build && electron-builder --linux",
-    "publish": "npm run build && electron-builder --publish=always"
+    "publish": "npm run build && electron-builder --publish=always",
+    "release": "node scripts/release.mjs"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/check-appdata-snapshot.mjs
+++ b/scripts/check-appdata-snapshot.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Release preflight: ensures a default app-data snapshot exists in
+// local-storage-data/ for the current AppData.LATEST_VERSION. See the
+// README "Releasing" section for why this matters and how to capture it.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const appDataTs = readFileSync(
+  join(repoRoot, 'src/renderer/src/model/AppDataManager/DataClasses/AppData.ts'),
+  'utf8',
+);
+const versionMatch = appDataTs.match(/export\s+const\s+LATEST_VERSION\s*=\s*(\d+)/);
+if (!versionMatch) {
+  console.error('Could not find "export const LATEST_VERSION = N" in AppData.ts.');
+  process.exit(2);
+}
+const latestVersion = Number(versionMatch[1]);
+
+const snapshotDir = join(repoRoot, 'local-storage-data');
+const pattern = new RegExp(`^appData-v${latestVersion}-.*\\.json$`);
+const matches = readdirSync(snapshotDir).filter((f) => pattern.test(f));
+
+if (matches.length === 0) {
+  console.error(
+    `Missing local-storage-data/appData-v${latestVersion}-*.json snapshot for the current AppData.LATEST_VERSION.\n` +
+      '\n' +
+      'To create one:\n' +
+      '  1. Run `npm run dev` and open the app.\n' +
+      '  2. Settings → General → Clear app data (or DevTools: localStorage.removeItem("appData"); location.reload();).\n' +
+      '  3. DevTools Console: copy(localStorage.getItem("appData"))\n' +
+      `  4. Save clipboard to local-storage-data/appData-v${latestVersion}-app-v<X.Y.Z>-default.json\n`,
+  );
+  process.exit(1);
+}
+
+console.log(`OK: ${matches[0]} covers AppData.LATEST_VERSION=${latestVersion}.`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// One-command release driver. Bumps version, finalizes CHANGELOG, commits,
+// tags, and pushes. CI (build-and-test.yml) picks up the tag push and
+// publishes the GitHub Release with signed artifacts and release notes
+// extracted from CHANGELOG.
+//
+// Usage:
+//   npm run release patch         # 5.10.0 -> 5.10.1
+//   npm run release minor         # 5.10.0 -> 5.11.0
+//   npm run release major         # 5.10.0 -> 6.0.0
+//   npm run release 5.11.0-rc.1   # explicit version
+//   npm run release patch --dry-run
+//   npm run release minor --allow-dev
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const allowDev = args.includes('--allow-dev');
+const bumpArg = args.find((a) => !a.startsWith('--'));
+
+if (!bumpArg) {
+  console.error('Usage: npm run release <patch|minor|major|X.Y.Z> [--dry-run] [--allow-dev]');
+  process.exit(2);
+}
+
+const sh = (cmd, opts = {}) =>
+  execSync(cmd, { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', ...opts }).trim();
+const shInherit = (cmd) => execSync(cmd, { cwd: repoRoot, stdio: 'inherit' });
+
+// --- Preflight ---------------------------------------------------------------
+
+const branch = sh('git rev-parse --abbrev-ref HEAD');
+if (branch !== 'main' && !allowDev) {
+  console.error(`Refusing to release from branch "${branch}". Pass --allow-dev to override.`);
+  process.exit(1);
+}
+
+const dirty = sh('git status --porcelain');
+if (dirty) {
+  console.error('Working tree is not clean. Commit or stash first:\n' + dirty);
+  process.exit(1);
+}
+
+console.log('Running typecheck...');
+shInherit('npx tsc');
+
+console.log('Running unit tests...');
+shInherit('npm run test:unit');
+
+console.log('Checking app-data snapshot...');
+shInherit('node scripts/check-appdata-snapshot.mjs');
+
+// --- Compute next version ----------------------------------------------------
+
+const pkgPath = join(repoRoot, 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const prevVersion = pkg.version;
+
+function bump(prev, kind) {
+  const m = prev.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!m) throw new Error(`Unparseable current version: ${prev}`);
+  let [, maj, min, pat] = m.map((v, i) => (i === 0 ? v : Number(v)));
+  if (kind === 'patch') pat += 1;
+  else if (kind === 'minor') { min += 1; pat = 0; }
+  else if (kind === 'major') { maj += 1; min = 0; pat = 0; }
+  else throw new Error(`Unknown bump kind: ${kind}`);
+  return `${maj}.${min}.${pat}`;
+}
+
+const newVersion = /^\d+\.\d+\.\d+/.test(bumpArg) ? bumpArg : bump(prevVersion, bumpArg);
+const newTag = `v${newVersion}`;
+
+if (sh('git tag -l ' + newTag)) {
+  console.error(`Tag ${newTag} already exists locally.`);
+  process.exit(1);
+}
+
+// --- Edit package.json -------------------------------------------------------
+
+const newPkg = readFileSync(pkgPath, 'utf8').replace(
+  /"version":\s*"[^"]+"/,
+  `"version": "${newVersion}"`,
+);
+
+// --- Edit CHANGELOG.md -------------------------------------------------------
+
+const changelogPath = join(repoRoot, 'CHANGELOG.md');
+let changelog = readFileSync(changelogPath, 'utf8');
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+if (!changelog.includes('## Unreleased')) {
+  console.error('CHANGELOG.md has no "## Unreleased" section; cannot finalize automatically.');
+  process.exit(1);
+}
+// 1. Insert the new version heading right after "## Unreleased" (leaving Unreleased empty for next cycle).
+changelog = changelog.replace(
+  /## Unreleased\n+/,
+  `## Unreleased\n\n## [${newVersion}] - ${today}\n\n`,
+);
+// 2. Insert compare link above the previous version's link entry.
+const compareLine = `[${newVersion}]: https://github.com/gbmhunter/NinjaTerm/compare/v${prevVersion}...v${newVersion}\n`;
+const prevLinkLine = `[${prevVersion}]: `;
+if (!changelog.includes(prevLinkLine)) {
+  console.error(`Could not find "${prevLinkLine}" compare-link anchor in CHANGELOG.md.`);
+  process.exit(1);
+}
+changelog = changelog.replace(prevLinkLine, compareLine + prevLinkLine);
+
+// --- Dry-run ----------------------------------------------------------------
+
+if (dryRun) {
+  console.log(`\n--- DRY RUN: would release ${newTag} (${prevVersion} -> ${newVersion}) ---`);
+  console.log(`\npackage.json version field would become: "${newVersion}"\n`);
+  console.log('CHANGELOG.md would gain heading:  ## [' + newVersion + '] - ' + today);
+  console.log('CHANGELOG.md would gain link:     ' + compareLine.trim());
+  console.log('\nNo files written, no commit made.');
+  process.exit(0);
+}
+
+// --- Apply + commit + tag + push --------------------------------------------
+
+writeFileSync(pkgPath, newPkg);
+writeFileSync(changelogPath, changelog);
+
+console.log(`\nCommitting release ${newTag}...`);
+shInherit('git add package.json CHANGELOG.md');
+shInherit(`git commit -m "Release ${newTag}"`);
+shInherit(`git tag ${newTag}`);
+
+console.log(`Pushing ${branch} and ${newTag}...`);
+shInherit(`git push origin ${branch} --follow-tags`);
+
+console.log(`\nDone. Watch CI: https://github.com/gbmhunter/NinjaTerm/actions`);
+console.log(`Release will appear at: https://github.com/gbmhunter/NinjaTerm/releases/tag/${newTag}`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,12 +5,11 @@
 // extracted from CHANGELOG.
 //
 // Usage:
-//   npm run release patch         # 5.10.0 -> 5.10.1
-//   npm run release minor         # 5.10.0 -> 5.11.0
-//   npm run release major         # 5.10.0 -> 6.0.0
-//   npm run release 5.11.0-rc.1   # explicit version
-//   npm run release patch --dry-run
-//   npm run release minor --allow-dev
+//   npm run release 5.11.0          # or any explicit semver
+//   npm run release v5.11.0         # v-prefix accepted, normalized away
+//   npm run release 5.11.0-rc.1     # prerelease
+//   npm run release 5.11.0 --dry-run
+//   npm run release 5.11.0 --allow-dev
 
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -21,10 +20,19 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const allowDev = args.includes('--allow-dev');
-const bumpArg = args.find((a) => !a.startsWith('--'));
+const rawVersionArg = args.find((a) => !a.startsWith('--'));
 
-if (!bumpArg) {
-  console.error('Usage: npm run release <patch|minor|major|X.Y.Z> [--dry-run] [--allow-dev]');
+if (!rawVersionArg) {
+  console.error('Usage: npm run release <X.Y.Z[-prerelease]> [--dry-run] [--allow-dev]');
+  console.error('Example: npm run release 5.11.0');
+  console.error('Example: npm run release 5.11.0-rc.1 --dry-run');
+  process.exit(2);
+}
+
+// Accept v-prefix (v5.11.0) — normalize it away. We re-add the `v` only for the git tag.
+const newVersion = rawVersionArg.replace(/^v/, '');
+if (!/^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/.test(newVersion)) {
+  console.error(`"${rawVersionArg}" is not a valid semver version (expected e.g. 5.11.0 or 5.11.0-rc.1).`);
   process.exit(2);
 }
 
@@ -55,26 +63,18 @@ shInherit('npm run test:unit');
 console.log('Checking app-data snapshot...');
 shInherit('node scripts/check-appdata-snapshot.mjs');
 
-// --- Compute next version ----------------------------------------------------
+// --- Record current version --------------------------------------------------
 
 const pkgPath = join(repoRoot, 'package.json');
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const prevVersion = pkg.version;
 
-function bump(prev, kind) {
-  const m = prev.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
-  if (!m) throw new Error(`Unparseable current version: ${prev}`);
-  let [, maj, min, pat] = m.map((v, i) => (i === 0 ? v : Number(v)));
-  if (kind === 'patch') pat += 1;
-  else if (kind === 'minor') { min += 1; pat = 0; }
-  else if (kind === 'major') { maj += 1; min = 0; pat = 0; }
-  else throw new Error(`Unknown bump kind: ${kind}`);
-  return `${maj}.${min}.${pat}`;
+if (newVersion === prevVersion) {
+  console.error(`New version ${newVersion} matches current package.json version; nothing to release.`);
+  process.exit(1);
 }
 
-const newVersion = /^\d+\.\d+\.\d+/.test(bumpArg) ? bumpArg : bump(prevVersion, bumpArg);
 const newTag = `v${newVersion}`;
-
 if (sh('git tag -l ' + newTag)) {
   console.error(`Tag ${newTag} already exists locally.`);
   process.exit(1);


### PR DESCRIPTION
Ships the release-process overhaul. User-visible changes are zero — everything is infra / tooling. Merging this lands the new workflow and release script on main, after which \`npm run release 5.11.0\` cuts v5.11.0 entirely from the command line.

## What's in this PR

- **`scripts/release.mjs`** — single-command driver: typecheck + unit tests + app-data-snapshot preflight, CHANGELOG finalization, \`package.json\` bump, commit, tag, push. Accepts an explicit semver arg (\`5.11.0\`, \`5.11.0-rc.1\`, with or without \`v\`). Flags: \`--dry-run\`, \`--allow-dev\`. No new npm deps.
- **`scripts/check-appdata-snapshot.mjs`** — verifies a matching \`local-storage-data/appData-v{N}-*.json\` exists for the current \`AppData.LATEST_VERSION\`. Blocks both the release script and the CI release job if missing.
- **`.github/workflows/build-and-test.yml`** — \`tags: ['v*']\` re-enabled. Branch pushes run \`test-electron\` with \`--publish never\` (packaging smoke-test, no upload). Tag pushes run \`test-electron\` → signed \`release\` job with \`--publish always\` → \`release-notes\` job that extracts the matching CHANGELOG section via \`awk\` and sets it as the Release body via \`gh release edit\`.
- **`README.md`** — \`## Releasing\` section rewritten around the new flow.

## Why

v5.10.0 exposed the old flow's footguns: 9-step manual walkthrough, a draft-release-with-matching-tag_name requirement that the README contradicted, commented-out \`tags:\` trigger paired with a dead \`release\` job inside the workflow, two overlapping publish modes, hand-pasted release bodies, easy-to-forget snapshot step.

## Validation

- \`npx tsc\` clean, 118/118 unit tests pass.
- Release-script dry-run verified locally: preflight runs, version math correct, CHANGELOG/package.json diffs match expectations, no writes.
- CHANGELOG awk-extract tested locally against the current file — cleanly extracts the \`## [5.10.0]\` section without the following \`## [5.9.0]\` heading.

## Post-merge

Once this is on main, run locally:

\`\`\`
git checkout main && git pull
npm run release 5.11.0
\`\`\`

…and watch CI do the rest.