### PR TITLE
Release-automation follow-ups after v5.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [5.11.1] - 2026-04-24
-
 ## [5.11.0] - 2026-04-24
 
 ### Changed
@@ -1008,7 +1006,6 @@ Fixed bug where pressing Ctrl-Shift-C to copy text from a terminal would enable 
 - Added special delete behaviour for backspace button when in "send on enter" mode, closes #90.
 
 [unreleased]: https://github.com/gbmhunter/NinjaTerm/compare/v5.9.0...HEAD
-[5.11.1]: https://github.com/gbmhunter/NinjaTerm/compare/v5.11.0...v5.11.1
 [5.11.0]: https://github.com/gbmhunter/NinjaTerm/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/gbmhunter/NinjaTerm/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/gbmhunter/NinjaTerm/compare/v5.8.2...v5.9.0

--- a/README.md
+++ b/README.md
@@ -130,9 +130,13 @@ Choosing a number follows semver:
 
 The script runs typecheck + unit tests + the snapshot preflight, finalizes
 CHANGELOG (moves `Unreleased` into a dated section and adds the compare link),
-writes `package.json`, commits `Release v{X.Y.Z}`, tags `v{X.Y.Z}`, and pushes
-`main` with the tag. Pass `--dry-run` to preview the changes without writing
-anything, or `--allow-dev` to release from the `dev` branch.
+writes `package.json`, commits `Release v{X.Y.Z}`, tags `v{X.Y.Z}` (annotated),
+and pushes `main` with the tag. Pass `--preview` to see what the changes would
+look like without writing anything, or `--allow-dev` to release from the `dev`
+branch.
+
+(We use `--preview` rather than `--dry-run` because npm intercepts `--dry-run`
+as one of its own flags before it reaches the script.)
 
 From there CI takes over: it builds and signs all three platforms, creates the
 GitHub Release, uploads the installers / updater manifests, and extracts the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ninjaterm",
   "productName": "NinjaTerm",
-  "version": "5.11.1",
+  "version": "5.11.0",
   "description": "A modern, powerful serial terminal for developers and engineers.",
   "author": {
     "name": "Geoffrey Hunter",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,8 @@
     "publish": {
       "provider": "github",
       "owner": "gbmhunter",
-      "repo": "NinjaTerm"
+      "repo": "NinjaTerm",
+      "releaseType": "release"
     }
   },
   "type": "module"

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,8 +8,13 @@
 //   npm run release 5.11.0          # or any explicit semver
 //   npm run release v5.11.0         # v-prefix accepted, normalized away
 //   npm run release 5.11.0-rc.1     # prerelease
-//   npm run release 5.11.0 --dry-run
+//   npm run release 5.11.0 --preview
 //   npm run release 5.11.0 --allow-dev
+//
+// NB: we use `--preview` instead of `--dry-run` because npm itself intercepts
+// `--dry-run` as one of its own CLI flags before passing args through to the
+// script (unless you write `npm run release -- 5.11.0 --dry-run`). Easier to
+// rename than to rely on users remembering the `--` separator.
 
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -18,14 +23,14 @@ import { dirname, join } from 'node:path';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const args = process.argv.slice(2);
-const dryRun = args.includes('--dry-run');
+const preview = args.includes('--preview');
 const allowDev = args.includes('--allow-dev');
 const rawVersionArg = args.find((a) => !a.startsWith('--'));
 
 if (!rawVersionArg) {
-  console.error('Usage: npm run release <X.Y.Z[-prerelease]> [--dry-run] [--allow-dev]');
+  console.error('Usage: npm run release <X.Y.Z[-prerelease]> [--preview] [--allow-dev]');
   console.error('Example: npm run release 5.11.0');
-  console.error('Example: npm run release 5.11.0-rc.1 --dry-run');
+  console.error('Example: npm run release 5.11.0-rc.1 --preview');
   process.exit(2);
 }
 
@@ -111,10 +116,10 @@ if (!changelog.includes(prevLinkLine)) {
 }
 changelog = changelog.replace(prevLinkLine, compareLine + prevLinkLine);
 
-// --- Dry-run ----------------------------------------------------------------
+// --- Preview ----------------------------------------------------------------
 
-if (dryRun) {
-  console.log(`\n--- DRY RUN: would release ${newTag} (${prevVersion} -> ${newVersion}) ---`);
+if (preview) {
+  console.log(`\n--- PREVIEW: would release ${newTag} (${prevVersion} -> ${newVersion}) ---`);
   console.log(`\npackage.json version field would become: "${newVersion}"\n`);
   console.log('CHANGELOG.md would gain heading:  ## [' + newVersion + '] - ' + today);
   console.log('CHANGELOG.md would gain link:     ' + compareLine.trim());
@@ -130,7 +135,10 @@ writeFileSync(changelogPath, changelog);
 console.log(`\nCommitting release ${newTag}...`);
 shInherit('git add package.json CHANGELOG.md');
 shInherit(`git commit -m "Release ${newTag}"`);
-shInherit(`git tag ${newTag}`);
+// Annotated tag (-a -m) so `git push --follow-tags` will push it alongside the
+// commit. Lightweight tags are NOT pushed by --follow-tags, which was a bug in
+// earlier versions of this script.
+shInherit(`git tag -a ${newTag} -m "Release ${newTag}"`);
 
 console.log(`Pushing ${branch} and ${newTag}...`);
 shInherit(`git push origin ${branch} --follow-tags`);


### PR DESCRIPTION
Three issues showed up during the v5.11.0 release. Fixing together:

## 1. `--dry-run` eaten by npm

Running \`npm run release 5.11.0 --dry-run\` did a real release because npm intercepted \`--dry-run\` as one of its own CLI flags before it reached the script. Renaming the flag to \`--preview\`, which npm doesn't intercept, is less fragile than relying on callers remembering the \`npm run ... -- ...\` separator convention. README updated.

## 2. Tag didn't reach origin

The release script used \`git tag <v>\` (lightweight) + \`git push --follow-tags\`, but \`--follow-tags\` only pushes *annotated* tags. v5.11.0's tag had to be pushed manually afterwards, which delayed CI and was confusing. Script now does \`git tag -a <v> -m \"Release <v>\"\`.

## 3. Release published as draft

Even with \`electron-builder --publish always\` the release was created as a draft (electron-builder's default). Added \`releaseType: \"release\"\` to the \`build.publish\` config so future tag pushes land a published release with no manual \"un-draft\" click.

## Bonus: revert accidental v5.11.1 commit

A preview-test attempt ran the old (pre-fix) script with an unrecognized \`--dry-run\` flag and cut a phantom v5.11.1 commit. No tag reached origin, no release exists. Reverted so \`main\`'s \`package.json\` matches the live v5.11.0 release.

## Validation

- \`npx tsc\` clean, 118/118 tests pass.
- The next \`npm run release <X.Y.Z>\` from main will: push an annotated tag, CI's \`release\` job will publish live (non-draft) artifacts, and the \`release-notes\` job will fill the body from CHANGELOG — fully hands-off.