### PR TITLE
Update CHANGELOG with Unreleased entries; require future updates in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- **Parser is dramatically faster on chunky data.** Replaced the O(n²) `Array.shift()` loop in `_parseAsciiData` with an indexed walk; switched the partial-escape buffer from per-byte string concat to a `number[]`; cached formatted timestamps at ms granularity. A 256 KB single chunk now parses ~14× faster (10 KB/s → 140 KB/s); typical streams ~2.4×. Methodology in `performance-profiles/THROUGHPUT_BASELINES.md`.
+- **Per-listener IPC disposers.** Every preload `on*(callback)` (serial, socket, RTT, Bluetooth, MCP, updater) now returns a disposer; `ConnController` collects them and clears on close, replacing the hand-maintained channel-name lists.
+- **Replaced `moment` with a tiny native formatter** (`Util/timestamp.ts`) — drops ~70 KB. Supports the moment tokens NinjaTerm uses; the `[literal]` escape syntax is not supported.
+- Open Graph / social card image is now NinjaTerm-branded (red, matching the app icon `logo512.png`) instead of the Docusaurus default.
+- Wired up real ESLint (flat `eslint.config.js`, typescript-eslint + react-hooks). Previous setup was the deprecated CRA `react-app` preset embedded in `package.json` and ESLint wasn't even in `devDependencies`. Runs via `npm run lint`; gates CI. `react-hooks/rules-of-hooks` at error, most other rules at warn for now.
+- Re-enabled `pull_request:` CI gating, bumped CodeQL action v2 → v3, added the missing `@shared` alias to `vitest.config.ts`.
+
+### Fixed
+
+- **Corrupt `localStorage` no longer crashes the renderer at startup.** Both `JSON.parse` sites in `AppDataManager` are now guarded; initial load falls back to defaults and overwrites the bad value, the cross-tab handler skips the sync.
+- **Socket auto-reconnect was stacking IPC listeners.** Each successful retry added three new listeners without disposing the prior set, so after N reconnects each byte fired `parseRxData` N times.
+- Bluetooth `discoveredDevices` no longer accumulates duplicates during long scans — same-id advertisements now replace the existing entry instead of pushing.
+- Bluetooth `txCharacteristic.on('data', ...)` handler is now removed on disconnect; previously each reconnect leaked the prior handler (along with its captured `mainWindow` / peripheral references).
+- `rxDataPoints` / `txDataPoints` are now bounded at 2048 entries — were growing unbounded under bursts of small chunks between 500 ms cleanup-interval ticks.
+- The MobX reaction in `App` and the `storage` event listener in `AppDataManager` are now disposed in `cleanup()`, so dev hot-reload doesn't leave stale handlers.
+- Main-process `uncaughtException` / `unhandledRejection` are now logged via `electron-log` instead of leaving the renderer talking to a half-initialised main process with no diagnostic trail.
+
 ## [5.11.1] - 2026-04-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,7 @@ npx tsc
 If updating any settings that are stored in the app data, make sure to add the migration code to the app data manager.
 
 Don't update the NinjaTerm application under web/, this is in maintenance mode and not updated unless it's a critical bug.
+
+When making changes that affect behaviour — features, bug fixes, performance changes, dependency drops, anything user- or developer-visible — add a corresponding entry to the `## Unreleased` section of `CHANGELOG.md` under `### Added` / `### Changed` / `### Fixed` as appropriate. Do this in the same PR as the change, not as a separate follow-up — once it's merged the context fades and the entry never gets written. Internal-only refactors with zero outward impact (e.g. renaming a private helper) don't need a CHANGELOG entry.
+
+**Keep entries terse.** Aim for one to two sentences total — the ones currently in the `## Unreleased` section are the model, not the older release sections (which got long). The standard shape is one bold-led clause that names the user-visible outcome, followed by ≤1 sentence of technical detail (key file / function names are fine; full paragraphs of context are not). Numbers and methodology that don't fit go in a linked file (e.g. `performance-profiles/THROUGHPUT_BASELINES.md`), not the entry. If an entry runs to three sentences or more, cut it back before merging.


### PR DESCRIPTION
## Summary

Fills the `## Unreleased` section of `CHANGELOG.md` with the work merged in #384, #385 and #386 since v5.11.1. Adds a CLAUDE.md instruction so future PRs include their own CHANGELOG entry at the time of the change.

## CHANGELOG entries added

**Changed**
- Parser ~14× faster on the worst-case 256 KB single-chunk benchmark (10 KB/s → 140 KB/s); 2-3× across normal scenarios. Methodology + numbers in `performance-profiles/THROUGHPUT_BASELINES.md`.
- Per-listener IPC disposers throughout the preload + `ConnController`; replaces hand-maintained channel-name lists.
- Replaced `moment` with a small native formatter (drops ~70 KB).
- Branded NinjaTerm social card replaces the Docusaurus default.
- ESLint properly wired up (flat config, `npm run lint`, gated in CI).
- Re-enabled PR CI; bumped CodeQL action v2 → v3; added `@shared` alias to vitest config.

**Fixed**
- Corrupt `localStorage` no longer crashes the renderer at startup.
- Socket auto-reconnect listener-stacking bug (N reconnects = N callbacks per byte).
- BLE `discoveredDevices` no longer accumulates duplicates during long scans.
- BLE `txCharacteristic.on('data', ...)` handler now removed on disconnect.
- `rxDataPoints` / `txDataPoints` capped at 2048 entries.
- App-level MobX reaction and AppDataManager `storage` listener now disposed in `cleanup()`.
- Main-process uncaught exceptions / unhandled rejections logged via `electron-log`.

#387 (OG image red recolour) is still open so it isn't covered here — it'll add its own line when it lands.

## CLAUDE.md addition

> When making changes that affect behaviour — features, bug fixes, performance changes, dependency drops, anything user- or developer-visible — add a corresponding entry to the `## Unreleased` section of `CHANGELOG.md` under `### Added` / `### Changed` / `### Fixed` as appropriate. Match the style of recent entries: a short bold-led one-line summary, then 1-3 sentences of technical detail (file/function names where useful). Do this in the same PR as the change, not as a separate follow-up — once it's merged the context fades and the entry never gets written. Internal-only refactors with zero outward impact (e.g. renaming a private helper) don't need a CHANGELOG entry.

## Test plan

- [ ] Sanity-read CHANGELOG.md to confirm the entries match what shipped in #384/#385/#386
- [ ] Decide whether to add #387's red OG image to Unreleased before merging this, or leave to its own follow-up