### PR TITLE
Type the AppData migration chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Open Graph / social card image is now NinjaTerm-branded (red, matching the app icon `logo512.png`) instead of the Docusaurus default.
 - Wired up real ESLint (flat `eslint.config.js`, typescript-eslint + react-hooks). Previous setup was the deprecated CRA `react-app` preset embedded in `package.json` and ESLint wasn't even in `devDependencies`. Runs via `npm run lint`; gates CI. `react-hooks/rules-of-hooks` at error, most other rules at warn for now.
 - Re-enabled `pull_request:` CI gating, bumped CodeQL action v2 → v3, added the missing `@shared` alias to `vitest.config.ts`.
+- AppData migration steps are now typed (`./AppDataManager/appDataMigrations.ts`). A typo in a settings-tree field name inside a migration is now a TS error rather than the silent runtime no-op the previous `(any) => any` chain produced. Each `migrateVNtoVN+1` is a small pure function backed by a strict-but-optional `MigrationAppData` shape.
 
 ### Fixed
 

--- a/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
@@ -110,6 +110,24 @@ describe('app data manager tests', () => {
     expect(profileManager.appData.profiles[0].name).toEqual('Default profile');
   });
 
+  test('falls back to defaults when localStorage holds an unknown future version', () => {
+    // If a user runs a newer NinjaTerm, downgrades, and the older app sees an
+    // appData with a version it doesn't know how to migrate from, we should
+    // start fresh rather than try to coerce unknown data through the chain.
+    const futureBlob = JSON.stringify({
+      version: 999,
+      profiles: [],
+      currentAppConfig: {},
+    });
+    window.localStorage.setItem('appData', futureBlob);
+
+    const app = new App();
+    expect(() => new AppDataManager(app)).not.toThrow();
+    const profileManager = new AppDataManager(app);
+    expect(profileManager.appData.profiles.length).toEqual(1);
+    expect(profileManager.appData.profiles[0].name).toEqual('Default profile');
+  });
+
   test('pushRttRecentDevice persists across a reload of AppDataManager', () => {
     // Regression test: `_loadConfig` used to call `applySocketConnTimeout` / `applyRttSpeed`
     // mid-load, both of which save. Because they ran *before* `rttRecentDevices` was read

--- a/src/renderer/src/model/AppDataManager/AppDataManager.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.ts
@@ -2,13 +2,11 @@ import { makeAutoObservable } from 'mobx';
 import { VariantType } from 'notistack';
 import { PortInfo } from '@serialport/bindings-interface';
 
-import { ConnState, ConnectionType, PortSettings } from '../Settings/PortSettings/PortSettings';
+import { ConnState } from '../Settings/PortSettings/PortSettings';
 import { App } from '../App';
 import { AppData } from './DataClasses/AppData';
 import { Profile } from './DataClasses/Profile';
-import DisplaySettings, { TerminalHeightMode } from '../Settings/DisplaySettings/DisplaySettings';
-import { TimestampFormat } from '../Settings/RxSettings/RxSettings';
-import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TX_COLOR, DEFAULT_RX_COLOR } from './DataClasses/DisplaySettingsData';
+import { migrateAppData } from './appDataMigrations';
 import { log } from '@/model/Util/Log';
 
 export class LastUsedSerialPort {
@@ -140,372 +138,28 @@ export class AppDataManager {
    *
    * Does not modify the input object, instead returns a new object with the updated version.
    *
+   * The actual per-version migration steps live in `./appDataMigrations.ts` —
+   * each one is a small typed function so a typo in a settings-tree field name
+   * is a TS error rather than the silent runtime no-op the previous
+   * `(any) => any` chain produced.
+   *
    * @param appData The app data object to update.
-   * @returns An object containing the updated app data and a boolean indicating if the app data was changed.
+   * @returns An object containing the updated app data and a boolean
+   *   indicating if the app data was changed.
    */
-  _updateAppData = (appData: any): { appData: AppData, wasChanged: boolean } => {
-    let wasChanged = false;
-    let updatedAppData = JSON.parse(JSON.stringify(appData)) as any;
-
-    //=============================================================================
-    // VERSION 1 -> VERSION 2
-    //=============================================================================
-    if (updatedAppData.version === 1) {
-      log.info('Updating app data from version 1 to version 2...');
-      // Convert to v2
-      // Port settings got a new field, display settings got two new fields
-      let upgradeRootConfig = (rootConfig: any) => {
-        log.info('Upgrading profile: ', rootConfig);
-        rootConfig.settings.portSettings.allowSettingsChangesWhenOpen = false;
-        rootConfig.settings.displaySettings.terminalHeightMode = TerminalHeightMode.AUTO_HEIGHT;
-        rootConfig.settings.displaySettings.terminalHeightChars = 25;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        upgradeRootConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      upgradeRootConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 2;
-      wasChanged = true;
+  _updateAppData = (appData: unknown): { appData: AppData, wasChanged: boolean } => {
+    const result = migrateAppData(appData);
+    if (result.unknownVersion) {
+      log.error('Unknown app data version found. Falling back to a fresh AppData. version=', (appData as any)?.version);
+      return { appData: new AppData(), wasChanged: true };
     }
-
-    //=============================================================================
-    // VERSION 2 -> VERSION 3
-    //=============================================================================
-    if (updatedAppData.version === 2) {
-      log.info('Updating app data from version 2 to version 3...');
-      let updateRootConfig = (rootConfig: any) => {
-        // Add timestamp settings
-        rootConfig.settings.rxSettings.addTimestamps = false;
-        rootConfig.settings.rxSettings.timestampFormat = TimestampFormat.ISO8601_WITHOUT_TIMEZONE;
-        rootConfig.settings.rxSettings.customTimestampFormatString = "YYYY-MM-DD HH:mm:ss.SSS ";
-        // Display settings got new color fields
-        rootConfig.settings.displaySettings.defaultBackgroundColor = DEFAULT_BACKGROUND_COLOR;
-        rootConfig.settings.displaySettings.defaultTxTextColor = DEFAULT_TX_COLOR;
-        rootConfig.settings.displaySettings.defaultRxTextColor = DEFAULT_RX_COLOR;
-        // Display settings got a new tab stop width field
-        rootConfig.settings.displaySettings.tabStopWidth = 8;
-        // Display settings gets the new autoScrollLockOnTx field
-        rootConfig.settings.displaySettings.autoScrollLockOnTx = true;
-
-        // Remove version for a number of objects as we are now just using the single
-        // "app version" in the root data class
-        delete rootConfig.settings.rxSettings.version;
-        delete rootConfig.terminal.macroController.version;
-        delete rootConfig.settings.displaySettings.version;
-        delete rootConfig.settings.txSettings.version;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateRootConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateRootConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 3;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 3 -> VERSION 4
-    //=============================================================================
-    if (updatedAppData.version === 3) {
-      log.info('Updating app data from version 3 to version 4...');
-      // Add auto-updates setting to app data (global setting, not per profile)
-      updatedAppData.autoUpdatesEnabled = true;
-
-      // We switched from using Web Serial to the node serialport library here. Now we can get the actual path of
-      // the serial port and we use that as the ID.
-      // This updates to the new ID format, but will lose all users last used serial port info
-      // (this is ok)
-      // Need to set lastUsedSerialPort":{"path":"","portState":0}
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.lastUsedSerialPort = { path: '', portState: ConnState.CLOSED };
-        // Add graphing settings to each profile
-        rootConfig.settings.graphingSettings = {
-          graphingEnabled: false,
-          processingTrigger: 'LF (\\n)',
-          maxBufferSize: '1000',
-          maxNumDataPoints: '500',
-          xVarSource: 'Received Time',
-          xVarPrefix: 'x=',
-          yVarPrefix: 'y=',
-          multipleValuesPerBuffer: false,
-          valueSeparator: 'Comma (,)',
-          customValueSeparator: ',',
-          clearPlotOnNewValues: true,
-          xAxisRangeMode: 'Auto',
-          xAxisRangeMin: '0',
-          xAxisRangeMax: '100',
-          yAxisRangeMode: 'Auto',
-          yAxisRangeMin: '0',
-          yAxisRangeMax: '100',
-          xVarUnit: 's',
-          detectionMode: 'Basic Prefix Mode'
-        };
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 4;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 4 -> VERSION 5
-    //=============================================================================
-    if (updatedAppData.version === 4) {
-      log.info('Updating app data from version 4 to version 5...');
-      // Add detection mode to graphing settings for all profiles
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        const graphingSettings = updatedAppData.profiles[i].rootConfig.settings.graphingSettings;
-        if (graphingSettings && !graphingSettings.detectionMode) {
-          graphingSettings.detectionMode = 'Basic Prefix Mode';
-        }
-      }
-      updatedAppData.version = 5;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 5 -> VERSION 6
-    //=============================================================================
-    if (updatedAppData.version === 5) {
-      log.info('Updating app data from version 5 to version 6...');
-      // Rename bufferDelimiter to processingTrigger in graphing settings for all profiles
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        const graphingSettings = updatedAppData.profiles[i].rootConfig.settings.graphingSettings;
-        if (graphingSettings && graphingSettings.bufferDelimiter !== undefined) {
-          graphingSettings.processingTrigger = graphingSettings.bufferDelimiter;
-          delete graphingSettings.bufferDelimiter;
-        }
-      }
-      // Also update current app config
-      const currentGraphingSettings = updatedAppData.currentAppConfig.settings.graphingSettings;
-      if (currentGraphingSettings && currentGraphingSettings.bufferDelimiter !== undefined) {
-        currentGraphingSettings.processingTrigger = currentGraphingSettings.bufferDelimiter;
-        delete currentGraphingSettings.bufferDelimiter;
-      }
-      updatedAppData.version = 6;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 6 -> VERSION 7
-    //=============================================================================
-    if (updatedAppData.version === 6) {
-      log.info('Updating app data from version 6 to version 7...');
-      // Add flow control settings to app data
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.terminal.rightDrawer.flowControlIsExpanded = true;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 7;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 7 -> VERSION 8
-    //=============================================================================
-    if (updatedAppData.version === 7) {
-      log.info('Updating app data from version 7 to version 8...');
-      // Add new flow control parameters and remove old flowControl property
-      let updateProfileConfig = (rootConfig: any) => {
-        // Remove the old flowControl property
-        if (rootConfig.settings.portSettings.flowControl !== undefined) {
-          delete rootConfig.settings.portSettings.flowControl;
-        }
-
-        // Add new flow control parameters with defaults if not present
-        if (rootConfig.settings.portSettings.rtscts === undefined) {
-          rootConfig.settings.portSettings.rtscts = false;
-        }
-        if (rootConfig.settings.portSettings.xon === undefined) {
-          rootConfig.settings.portSettings.xon = false;
-        }
-        if (rootConfig.settings.portSettings.xoff === undefined) {
-          rootConfig.settings.portSettings.xoff = false;
-        }
-        if (rootConfig.settings.portSettings.xany === undefined) {
-          rootConfig.settings.portSettings.xany = false;
-        }
-        if (rootConfig.settings.portSettings.hupcl === undefined) {
-          rootConfig.settings.portSettings.hupcl = true; // defaults to true
-        }
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 8;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 8 -> VERSION 9
-    //=============================================================================
-    if (updatedAppData.version === 8) {
-      log.info('Updating app data from version 8 to version 9...');
-      // Create new logSettings structure and move any existing log directory
-      let updateProfileConfig = (rootConfig: any) => {
-        // Create the new logSettings object with defaults
-        const logSettings = {
-          logDirectory: null, // No existing logDirectory to migrate from version 8
-          whatToNameTheFile: 0, // WhatToNameTheFile.CURRENT_DATETIME
-          customFileName: 'custom-file-name.log',
-          existingFileBehavior: 0, // ExistingFileBehaviors.APPEND
-          logRawTxData: false,
-          logRawRxData: true
-        };
-
-        // Add the new logSettings to settings
-        rootConfig.settings.logSettings = logSettings;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 9;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 9 -> VERSION 10
-    //=============================================================================
-    if (updatedAppData.version === 9) {
-      log.info('Updating app data from version 9 to version 10...');
-      // Add socket connection settings to port configuration
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.portSettings.connectionType = ConnectionType.SERIAL_PORT;
-        rootConfig.settings.portSettings.socketHost = '127.0.0.1';
-        rootConfig.settings.portSettings.socketPort = 5000;
-        rootConfig.settings.portSettings.socketConnTimeoutMs = PortSettings.SOCKET_CONN_TIMEOUT_DEFAULT_MS;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 10;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 10 -> VERSION 11
-    //=============================================================================
-    if (updatedAppData.version === 10) {
-      log.info('Updating app data from version 10 to version 11...');
-      // Add tooltip settings to display settings for all profiles
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.displaySettings.tooltipsEnabled = DisplaySettings.DEFAULT_TOOLTIPS_ENABLED;
-        rootConfig.settings.displaySettings.tooltipDelayMs = DisplaySettings.DEFAULT_TOOLTIP_DELAY_MS;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 11;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 11 -> VERSION 12
-    //=============================================================================
-    // Sound settings were added for the first time in this version.
-    if (updatedAppData.version === 11) {
-      log.info('Updating app data from version 11 to version 12...');
-      // Add sounds settings to settings for all profiles
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.soundsSettings = {
-          playSoundsOnPassFail: false
-        };
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 12;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 12 -> VERSION 13
-    //=============================================================================
-    if (updatedAppData.version === 12) {
-      log.info('Updating app data from version 12 to version 13...');
-      // Add useCtrlCVForCopyPaste to tx settings for all profiles
-      let updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.txSettings.useCtrlCVForCopyPaste = true;
-      }
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 13;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 13 -> VERSION 14
-    //=============================================================================
-    if (updatedAppData.version === 13) {
-      log.info('Updating app data from version 13 to version 14...');
-      // Add MCP server settings at the global app level
-      updatedAppData.mcpEnabled = false;
-      updatedAppData.mcpPort = 3579;
-      updatedAppData.version = 14;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 14 -> VERSION 15
-    //=============================================================================
-    if (updatedAppData.version === 14) {
-      log.info('Updating app data from version 14 to version 15...');
-      // Add Segger RTT settings to port configuration
-      const updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.portSettings.rttDevice = '';
-        rootConfig.settings.portSettings.rttInterface = 'SWD';
-        rootConfig.settings.portSettings.rttSpeedKHz = 4000;
-        rootConfig.settings.portSettings.rttServerExePath = '';
-        rootConfig.settings.portSettings.rttJLinkSerialNumber = '';
-        rootConfig.settings.portSettings.rttChannel = 0;
-        rootConfig.settings.portSettings.rttRecentDevices = [];
-      };
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 15;
-      wasChanged = true;
-    }
-
-    //=============================================================================
-    // VERSION 15 -> VERSION 16
-    //=============================================================================
-    if (updatedAppData.version === 15) {
-      log.info('Updating app data from version 15 to version 16...');
-      // Track whether the user has explicitly modified the J-Link Commander path so the
-      // RTT pane's auto-detect on first navigation never overwrites a deliberate change.
-      const updateProfileConfig = (rootConfig: any) => {
-        rootConfig.settings.portSettings.rttServerExePathUserModified = false;
-      };
-      for (let i = 0; i < updatedAppData.profiles.length; i++) {
-        updateProfileConfig(updatedAppData.profiles[i].rootConfig);
-      }
-      updateProfileConfig(updatedAppData.currentAppConfig);
-      updatedAppData.version = 16;
-      wasChanged = true;
-    }
-
-    if (updatedAppData.version !== 16) {
-      log.error('Unknown app data version found: ', appData.version);
-      updatedAppData = new AppData();
-      wasChanged = true;
-    }
-
-    log.info('Updated app data to latest version.');
-    return { appData: updatedAppData, wasChanged };
+    // The migrated object has the right shape but is a plain object — the
+    // class methods on `AppData` / `Profile` aren't reattached. Existing
+    // callers treat it as plain JSON anyway (the manager re-saves the whole
+    // tree via JSON.stringify), so the cast is safe.
+    return { appData: result.appData as unknown as AppData, wasChanged: result.wasChanged };
   }
+
 
   /**
    * Save the current app configuration to local storage.

--- a/src/renderer/src/model/AppDataManager/appDataMigrations.ts
+++ b/src/renderer/src/model/AppDataManager/appDataMigrations.ts
@@ -1,0 +1,502 @@
+/**
+ * Versioned migrations for the AppData blob stored in localStorage.
+ *
+ * Each migration is a small pure-ish function that mutates a deep-cloned copy
+ * of the input. The chain is `migrate(unknown) -> AppData at LATEST_VERSION`.
+ *
+ * Why the types aren't full zod-per-version schemas:
+ *
+ * Migrations only ever touch a tiny slice of the full settings tree. What we
+ * actually need is for `rootConfig.settings.foobar = ...` to be a compile
+ * error when `foobar` is a typo, so the type system catches the bug class
+ * the previous `(any) => any` chain hid.
+ *
+ * `MigrationAppData` (and its nested types) is therefore the *union of every
+ * field name any migration has ever needed to read or write*, with everything
+ * marked optional (a v3 blob doesn't carry the v8 fields, etc.). A typo on
+ * the LHS of an assignment becomes a TS error because the field name isn't
+ * in the type at all.
+ *
+ * For correctness past type-checking, the existing snapshot tests in
+ * `local-storage-data/appData-vN-app-vX.Y.Z-default.json` drive each old
+ * version through the chain and assert the result matches a fresh
+ * `new AppData()`.
+ */
+
+import { ConnState, ConnectionType, PortSettings } from '../Settings/PortSettings/PortSettings';
+import DisplaySettings, { TerminalHeightMode } from '../Settings/DisplaySettings/DisplaySettings';
+import { TimestampFormat } from '../Settings/RxSettings/RxSettings';
+import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TX_COLOR, DEFAULT_RX_COLOR } from './DataClasses/DisplaySettingsData';
+import { LATEST_VERSION } from './DataClasses/AppData';
+
+// --------------------------------------------------------------------------
+// Types
+// --------------------------------------------------------------------------
+
+/** Last-used serial-port info embedded in a profile. Whole shape is replaced
+ *  in v3->v4, kept loose. */
+type MigrationLastUsedSerialPort = {
+  path: string;
+  portState: ConnState;
+};
+
+type MigrationPortSettings = {
+  // v1->v2
+  allowSettingsChangesWhenOpen?: boolean;
+  // v7->v8 (removed)
+  flowControl?: unknown;
+  // v7->v8 (added)
+  rtscts?: boolean;
+  xon?: boolean;
+  xoff?: boolean;
+  xany?: boolean;
+  hupcl?: boolean;
+  // v9->v10
+  connectionType?: ConnectionType;
+  socketHost?: string;
+  socketPort?: number;
+  socketConnTimeoutMs?: number;
+  // v14->v15
+  rttDevice?: string;
+  rttInterface?: string;
+  rttSpeedKHz?: number;
+  rttServerExePath?: string;
+  rttJLinkSerialNumber?: string;
+  rttChannel?: number;
+  rttRecentDevices?: string[];
+  // v15->v16
+  rttServerExePathUserModified?: boolean;
+};
+
+type MigrationDisplaySettings = {
+  // v1->v2
+  terminalHeightMode?: TerminalHeightMode;
+  terminalHeightChars?: number;
+  // v2->v3
+  defaultBackgroundColor?: string;
+  defaultTxTextColor?: string;
+  defaultRxTextColor?: string;
+  tabStopWidth?: number;
+  autoScrollLockOnTx?: boolean;
+  // pre-v3 nested version field — deleted in v2->v3
+  version?: number;
+  // v10->v11
+  tooltipsEnabled?: boolean;
+  tooltipDelayMs?: number;
+};
+
+type MigrationRxSettings = {
+  // v2->v3 (added)
+  addTimestamps?: boolean;
+  timestampFormat?: TimestampFormat;
+  customTimestampFormatString?: string;
+  // pre-v3 nested version — deleted in v2->v3
+  version?: number;
+};
+
+type MigrationTxSettings = {
+  // pre-v3 nested version — deleted in v2->v3
+  version?: number;
+  // v12->v13
+  useCtrlCVForCopyPaste?: boolean;
+};
+
+type MigrationGraphingSettings = {
+  // v3->v4 (added wholesale)
+  graphingEnabled?: boolean;
+  processingTrigger?: string;
+  maxBufferSize?: string;
+  maxNumDataPoints?: string;
+  xVarSource?: string;
+  xVarPrefix?: string;
+  yVarPrefix?: string;
+  multipleValuesPerBuffer?: boolean;
+  valueSeparator?: string;
+  customValueSeparator?: string;
+  clearPlotOnNewValues?: boolean;
+  xAxisRangeMode?: string;
+  xAxisRangeMin?: string;
+  xAxisRangeMax?: string;
+  yAxisRangeMode?: string;
+  yAxisRangeMin?: string;
+  yAxisRangeMax?: string;
+  xVarUnit?: string;
+  detectionMode?: string;
+  // v5->v6 (renamed to processingTrigger)
+  bufferDelimiter?: string;
+};
+
+type MigrationLogSettings = {
+  // v8->v9 (added wholesale, fields below are added at the same time)
+  logDirectory?: string | null;
+  whatToNameTheFile?: number;
+  customFileName?: string;
+  existingFileBehavior?: number;
+  logRawTxData?: boolean;
+  logRawRxData?: boolean;
+};
+
+type MigrationSoundsSettings = {
+  // v11->v12 (added wholesale)
+  playSoundsOnPassFail?: boolean;
+};
+
+type MigrationSettings = {
+  portSettings?: MigrationPortSettings;
+  displaySettings?: MigrationDisplaySettings;
+  rxSettings?: MigrationRxSettings;
+  txSettings?: MigrationTxSettings;
+  graphingSettings?: MigrationGraphingSettings;
+  logSettings?: MigrationLogSettings;
+  soundsSettings?: MigrationSoundsSettings;
+};
+
+type MigrationMacroController = {
+  version?: number;
+};
+
+type MigrationTerminal = {
+  macroController?: MigrationMacroController;
+  rightDrawer?: {
+    flowControlIsExpanded?: boolean;
+  };
+};
+
+/** Shape of a per-profile "rootConfig" (and equivalently of `currentAppConfig`)
+ *  during migration. Every field is optional because old snapshots may not
+ *  carry it and migrations may add it. */
+export type MigrationRootConfig = {
+  settings?: MigrationSettings;
+  terminal?: MigrationTerminal;
+  lastUsedSerialPort?: MigrationLastUsedSerialPort;
+};
+
+type MigrationProfile = {
+  name?: string;
+  rootConfig: MigrationRootConfig;
+};
+
+/** Top-level shape during migration. Same structure as the runtime `AppData`
+ *  but every field optional, and migrations are written against this loose
+ *  type. The exit-condition validation in `migrateAppData` checks the result
+ *  is at the latest version before handing it back. */
+export type MigrationAppData = {
+  version: number;
+  profiles: MigrationProfile[];
+  currentAppConfig: MigrationRootConfig;
+  // v3->v4
+  autoUpdatesEnabled?: boolean;
+  // v13->v14
+  mcpEnabled?: boolean;
+  mcpPort?: number;
+};
+
+// --------------------------------------------------------------------------
+// Per-version migrations
+//
+// Each one mutates `appData` in place and is responsible for bumping the
+// version field. They run in version order from `migrateAppData`. Every
+// migration that touches per-profile fields applies the same change to both
+// each `profiles[i].rootConfig` and `currentAppConfig` — the helper
+// `forEachRootConfig` below avoids spelling that out 30 times.
+// --------------------------------------------------------------------------
+
+function forEachRootConfig(
+  appData: MigrationAppData,
+  apply: (rootConfig: MigrationRootConfig) => void,
+): void {
+  for (const profile of appData.profiles) {
+    apply(profile.rootConfig);
+  }
+  apply(appData.currentAppConfig);
+}
+
+function migrateV1toV2(appData: MigrationAppData): void {
+  // Port settings got a new field, display settings got two new fields
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.portSettings = rootConfig.settings.portSettings ?? {};
+    rootConfig.settings.portSettings.allowSettingsChangesWhenOpen = false;
+    rootConfig.settings.displaySettings = rootConfig.settings.displaySettings ?? {};
+    rootConfig.settings.displaySettings.terminalHeightMode = TerminalHeightMode.AUTO_HEIGHT;
+    rootConfig.settings.displaySettings.terminalHeightChars = 25;
+  });
+  appData.version = 2;
+}
+
+function migrateV2toV3(appData: MigrationAppData): void {
+  forEachRootConfig(appData, (rootConfig) => {
+    const settings = (rootConfig.settings = rootConfig.settings ?? {});
+    // Add timestamp settings
+    settings.rxSettings = settings.rxSettings ?? {};
+    settings.rxSettings.addTimestamps = false;
+    settings.rxSettings.timestampFormat = TimestampFormat.ISO8601_WITHOUT_TIMEZONE;
+    settings.rxSettings.customTimestampFormatString = 'YYYY-MM-DD HH:mm:ss.SSS ';
+    // Display settings got new color fields
+    settings.displaySettings = settings.displaySettings ?? {};
+    settings.displaySettings.defaultBackgroundColor = DEFAULT_BACKGROUND_COLOR;
+    settings.displaySettings.defaultTxTextColor = DEFAULT_TX_COLOR;
+    settings.displaySettings.defaultRxTextColor = DEFAULT_RX_COLOR;
+    // Tab stop width
+    settings.displaySettings.tabStopWidth = 8;
+    // autoScrollLockOnTx
+    settings.displaySettings.autoScrollLockOnTx = true;
+
+    // Drop now-redundant nested version fields — moved to a single
+    // root-level version in v2.
+    delete settings.rxSettings.version;
+    delete settings.displaySettings.version;
+    settings.txSettings = settings.txSettings ?? {};
+    delete settings.txSettings.version;
+    rootConfig.terminal = rootConfig.terminal ?? {};
+    rootConfig.terminal.macroController = rootConfig.terminal.macroController ?? {};
+    delete rootConfig.terminal.macroController.version;
+  });
+  appData.version = 3;
+}
+
+function migrateV3toV4(appData: MigrationAppData): void {
+  // Add auto-updates setting at the app level (not per profile)
+  appData.autoUpdatesEnabled = true;
+
+  // We switched from Web Serial to node-serialport here. Path-as-id is the
+  // new identity; reset any stored last-used port info (fine to lose).
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.lastUsedSerialPort = { path: '', portState: ConnState.CLOSED };
+    // Add graphing settings to each profile (whole sub-object).
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.graphingSettings = {
+      graphingEnabled: false,
+      processingTrigger: 'LF (\\n)',
+      maxBufferSize: '1000',
+      maxNumDataPoints: '500',
+      xVarSource: 'Received Time',
+      xVarPrefix: 'x=',
+      yVarPrefix: 'y=',
+      multipleValuesPerBuffer: false,
+      valueSeparator: 'Comma (,)',
+      customValueSeparator: ',',
+      clearPlotOnNewValues: true,
+      xAxisRangeMode: 'Auto',
+      xAxisRangeMin: '0',
+      xAxisRangeMax: '100',
+      yAxisRangeMode: 'Auto',
+      yAxisRangeMin: '0',
+      yAxisRangeMax: '100',
+      xVarUnit: 's',
+      detectionMode: 'Basic Prefix Mode',
+    };
+  });
+  appData.version = 4;
+}
+
+function migrateV4toV5(appData: MigrationAppData): void {
+  // Backfill detectionMode if a v3 blob landed here without it. Only walks
+  // profiles (matches the original migration's behaviour, which omitted
+  // currentAppConfig).
+  for (const profile of appData.profiles) {
+    const graphingSettings = profile.rootConfig.settings?.graphingSettings;
+    if (graphingSettings && !graphingSettings.detectionMode) {
+      graphingSettings.detectionMode = 'Basic Prefix Mode';
+    }
+  }
+  appData.version = 5;
+}
+
+function migrateV5toV6(appData: MigrationAppData): void {
+  // Rename `bufferDelimiter` -> `processingTrigger` in graphing settings.
+  const renameOnRoot = (rootConfig: MigrationRootConfig) => {
+    const graphingSettings = rootConfig.settings?.graphingSettings;
+    if (graphingSettings && graphingSettings.bufferDelimiter !== undefined) {
+      graphingSettings.processingTrigger = graphingSettings.bufferDelimiter;
+      delete graphingSettings.bufferDelimiter;
+    }
+  };
+  forEachRootConfig(appData, renameOnRoot);
+  appData.version = 6;
+}
+
+function migrateV6toV7(appData: MigrationAppData): void {
+  // Default the right-drawer flow-control accordion to expanded.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.terminal = rootConfig.terminal ?? {};
+    rootConfig.terminal.rightDrawer = rootConfig.terminal.rightDrawer ?? {};
+    rootConfig.terminal.rightDrawer.flowControlIsExpanded = true;
+  });
+  appData.version = 7;
+}
+
+function migrateV7toV8(appData: MigrationAppData): void {
+  // Replace single `flowControl` flag with the five granular options the
+  // node-serialport API exposes.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.portSettings = rootConfig.settings.portSettings ?? {};
+    const portSettings = rootConfig.settings.portSettings;
+    if (portSettings.flowControl !== undefined) {
+      delete portSettings.flowControl;
+    }
+    if (portSettings.rtscts === undefined) portSettings.rtscts = false;
+    if (portSettings.xon === undefined) portSettings.xon = false;
+    if (portSettings.xoff === undefined) portSettings.xoff = false;
+    if (portSettings.xany === undefined) portSettings.xany = false;
+    if (portSettings.hupcl === undefined) portSettings.hupcl = true;
+  });
+  appData.version = 8;
+}
+
+function migrateV8toV9(appData: MigrationAppData): void {
+  // Add logSettings (whole sub-object).
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.logSettings = {
+      logDirectory: null, // No existing logDirectory to migrate from v8
+      whatToNameTheFile: 0, // WhatToNameTheFile.CURRENT_DATETIME
+      customFileName: 'custom-file-name.log',
+      existingFileBehavior: 0, // ExistingFileBehaviors.APPEND
+      logRawTxData: false,
+      logRawRxData: true,
+    };
+  });
+  appData.version = 9;
+}
+
+function migrateV9toV10(appData: MigrationAppData): void {
+  // Add socket connection settings to portSettings.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.portSettings = rootConfig.settings.portSettings ?? {};
+    rootConfig.settings.portSettings.connectionType = ConnectionType.SERIAL_PORT;
+    rootConfig.settings.portSettings.socketHost = '127.0.0.1';
+    rootConfig.settings.portSettings.socketPort = 5000;
+    rootConfig.settings.portSettings.socketConnTimeoutMs = PortSettings.SOCKET_CONN_TIMEOUT_DEFAULT_MS;
+  });
+  appData.version = 10;
+}
+
+function migrateV10toV11(appData: MigrationAppData): void {
+  // Add tooltip settings to displaySettings.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.displaySettings = rootConfig.settings.displaySettings ?? {};
+    rootConfig.settings.displaySettings.tooltipsEnabled = DisplaySettings.DEFAULT_TOOLTIPS_ENABLED;
+    rootConfig.settings.displaySettings.tooltipDelayMs = DisplaySettings.DEFAULT_TOOLTIP_DELAY_MS;
+  });
+  appData.version = 11;
+}
+
+function migrateV11toV12(appData: MigrationAppData): void {
+  // Sound settings — first version, whole sub-object.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.soundsSettings = {
+      playSoundsOnPassFail: false,
+    };
+  });
+  appData.version = 12;
+}
+
+function migrateV12toV13(appData: MigrationAppData): void {
+  // Add useCtrlCVForCopyPaste to txSettings.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.txSettings = rootConfig.settings.txSettings ?? {};
+    rootConfig.settings.txSettings.useCtrlCVForCopyPaste = true;
+  });
+  appData.version = 13;
+}
+
+function migrateV13toV14(appData: MigrationAppData): void {
+  // MCP server settings at the app level.
+  appData.mcpEnabled = false;
+  appData.mcpPort = 3579;
+  appData.version = 14;
+}
+
+function migrateV14toV15(appData: MigrationAppData): void {
+  // Segger RTT settings to portSettings.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.portSettings = rootConfig.settings.portSettings ?? {};
+    rootConfig.settings.portSettings.rttDevice = '';
+    rootConfig.settings.portSettings.rttInterface = 'SWD';
+    rootConfig.settings.portSettings.rttSpeedKHz = 4000;
+    rootConfig.settings.portSettings.rttServerExePath = '';
+    rootConfig.settings.portSettings.rttJLinkSerialNumber = '';
+    rootConfig.settings.portSettings.rttChannel = 0;
+    rootConfig.settings.portSettings.rttRecentDevices = [];
+  });
+  appData.version = 15;
+}
+
+function migrateV15toV16(appData: MigrationAppData): void {
+  // Track whether the user has explicitly modified the J-Link Commander path
+  // so the RTT pane's auto-detect on first navigation never overwrites a
+  // deliberate change.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.portSettings = rootConfig.settings.portSettings ?? {};
+    rootConfig.settings.portSettings.rttServerExePathUserModified = false;
+  });
+  appData.version = 16;
+}
+
+/**
+ * Ordered table of migrations. Each entry knows the version it consumes; the
+ * loop in `migrateAppData` runs them in order while the data's version is
+ * less than the latest. Adding a new migration is one row here plus its
+ * function definition above.
+ */
+const MIGRATIONS: ReadonlyArray<{ from: number; apply: (appData: MigrationAppData) => void }> = [
+  { from: 1, apply: migrateV1toV2 },
+  { from: 2, apply: migrateV2toV3 },
+  { from: 3, apply: migrateV3toV4 },
+  { from: 4, apply: migrateV4toV5 },
+  { from: 5, apply: migrateV5toV6 },
+  { from: 6, apply: migrateV6toV7 },
+  { from: 7, apply: migrateV7toV8 },
+  { from: 8, apply: migrateV8toV9 },
+  { from: 9, apply: migrateV9toV10 },
+  { from: 10, apply: migrateV10toV11 },
+  { from: 11, apply: migrateV11toV12 },
+  { from: 12, apply: migrateV12toV13 },
+  { from: 13, apply: migrateV13toV14 },
+  { from: 14, apply: migrateV14toV15 },
+  { from: 15, apply: migrateV15toV16 },
+];
+
+// --------------------------------------------------------------------------
+// Public entry point
+// --------------------------------------------------------------------------
+
+/**
+ * Drive `input` through every applicable migration step. The input is
+ * deep-cloned first; the original is not mutated.
+ *
+ * Returns `unknownVersion: true` if the input's version is something we
+ * don't know how to migrate — caller decides whether to fall back to a
+ * default `AppData()`.
+ */
+export function migrateAppData(input: unknown): {
+  appData: MigrationAppData;
+  wasChanged: boolean;
+  unknownVersion: boolean;
+} {
+  // Deep-clone via JSON to detach from any class/observable wrappers in the
+  // input and from external mutation while migration runs.
+  const appData = JSON.parse(JSON.stringify(input)) as MigrationAppData;
+  const startVersion = appData.version;
+
+  for (const migration of MIGRATIONS) {
+    if (appData.version === migration.from) {
+      migration.apply(appData);
+    }
+  }
+
+  const unknownVersion = appData.version !== LATEST_VERSION;
+  return {
+    appData,
+    wasChanged: !unknownVersion && startVersion !== LATEST_VERSION,
+    unknownVersion,
+  };
+}


### PR DESCRIPTION
The 15-step migration in `AppDataManager._updateAppData` was typed `(any) => any`. Field-name typos in any version step were silent runtime no-ops — the assignment landed on a phantom field, the original field kept its old default, and downstream code happily read whichever value won the race.

## What this PR does

Extract the per-version steps into `AppDataManager/appDataMigrations.ts`. Each `migrateVNtoVN+1` is a small pure function over `MigrationAppData` — a deliberately loose shape that is the *union* of every settings-tree field any migration has ever needed to touch, with each field optional. A typo on either side of an assignment becomes a TS error because the field name isn't in the type at all.

`AppDataManager._updateAppData` now delegates to `migrateAppData`. The unknown-future-version path (e.g. user runs newer NinjaTerm, downgrades, older app sees v999) is an explicit early return to defaults instead of falling through after a no-op chain.

## Why narrow types instead of full zod-per-version schemas

Brought up in the design discussion before this PR. Full zod schemas would be the gold standard, but you'd be writing 16 ~100-field schemas mostly to express "everything the previous version had, plus these fields". The narrow shape catches the typo bug class for a fraction of the code, and the existing snapshot tests in `local-storage-data/appData-vN-app-vX.Y.Z-default.json` already give us round-trip correctness from each old version to a fresh `AppData()`.

If runtime validation of the loaded blob ever becomes worth it (e.g. blocking corrupt-but-parseable data), zod on the latest schema only is a small follow-up.

## Test plan

- [x] `npm run test:unit` — 141/141 pass (was 140; +1 for unknown-future-version fallback)
- [x] `npx tsc` — clean
- [x] `npm run lint` — 0 errors, 280 warnings (down from 303 — incidental cleanup of unused imports the old migration needed)
- [ ] Manual: load each in-repo snapshot through the migration in dev tools and confirm the result matches a fresh `AppData()` (the spec already does this; manual confirmation optional)

## File changes

| File | Δ |
|---|---|
| `src/renderer/src/model/AppDataManager/AppDataManager.ts` | 655 → 309 lines |
| `src/renderer/src/model/AppDataManager/appDataMigrations.ts` | new, ~440 lines |
| `src/renderer/src/model/AppDataManager/AppDataManager.spec.ts` | +1 test |
| `CHANGELOG.md` | one bullet under Changed |