### PR TITLE
Lint debt cleanup pass 1: 280 -> 102 warnings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu, shell, session } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, Menu, shell } from 'electron';
 import pkg from 'electron-updater';
 const { autoUpdater } = pkg;
 import * as path from 'path';
@@ -73,7 +73,6 @@ function emitEventIfInProd(event: string) {
   }
 }
 
-
 // Configure auto-updater logging
 autoUpdater.logger = mainLogger;
 (autoUpdater.logger as any).transports.file.level = 'info';
@@ -132,8 +131,8 @@ autoUpdater.on('update-downloaded', (info) => {
   mainWindow?.webContents.send('update-downloaded', info);
 });
 
-// Initialize Bluetooth service (will be updated with mainWindow after createWindow)
-let bluetoothService: any;
+// Bluetooth service registers its IPC handlers in the constructor; we don't
+// keep a reference because nothing else in this file calls it back.
 
 let mcpService: McpService | null = null;
 
@@ -215,7 +214,8 @@ app.whenReady().then(async () => {
     try {
       // require didn't work here, so using import instead
       const { MainBluetoothService } = await import('./MainBluetoothService');
-      bluetoothService = new MainBluetoothService(mainWindow);
+      // Constructor registers its IPC handlers via side effects; no need to retain a reference.
+      new MainBluetoothService(mainWindow);
     } catch (error) {
       console.error('Failed to load Bluetooth service:', error);
     }
@@ -283,7 +283,6 @@ app.on('activate', () => {
   }
 });
 
-
 // File system operations for logging
 ipcMain.handle('fs:select-directory', async () => {
   try {
@@ -326,11 +325,11 @@ ipcMain.handle('fs:get-file-size', async (event, filePath: string) => {
   }
 });
 
-ipcMain.handle('fs:file-exists', async (event, filePath: string) => {
+ipcMain.handle('fs:file-exists', async (_event, filePath: string) => {
   try {
     await fs.access(filePath);
     return { success: true, exists: true };
-  } catch (error) {
+  } catch {
     return { success: true, exists: false };
   }
 });

--- a/src/main/rttService.ts
+++ b/src/main/rttService.ts
@@ -193,7 +193,7 @@ function startRxPolling(mainWindow: BrowserWindow, session: RttSession) {
 function startProbePresencePolling(mainWindow: BrowserWindow, session: RttSession) {
   session.presencePollTimer = setInterval(() => {
     if (session.closed) return;
-    let connected = 0;
+    let connected: number;
     try {
       connected = session.api.emuIsConnected();
     } catch {

--- a/src/main/serialService.ts
+++ b/src/main/serialService.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, ipcMain } from 'electron';
 import { SerialPort } from 'serialport';
-import { OpenOptions, PortStatus, SetOptions } from '@serialport/bindings-interface';
+import { OpenOptions, PortStatus } from '@serialport/bindings-interface';
 
 import { Parity } from '@/model/Settings/PortSettings/PortSettings';
 import { log } from './Logging';
@@ -171,7 +171,7 @@ export function initializeSerialHandlers(mainWindow: BrowserWindow) {
   });
 
   ipcMain.handle('serial:close-all-ports', async () => {
-    for (const [portPath, port] of activeSerialPorts) {
+    for (const [, port] of activeSerialPorts) {
       await port.close();
     }
 

--- a/src/main/socketService.ts
+++ b/src/main/socketService.ts
@@ -222,12 +222,12 @@ export function initializeSocketHandlers(mainWindow: BrowserWindow) {
         return { success: false, error: 'Socket not found' };
       }
 
-      await new Promise<void>((resolve, reject) => {
+      await new Promise<void>((resolve, _reject) => {
         socket.end(() => {
           resolve();
         });
 
-        socket.on('error', (err) => {
+        socket.on('error', (_err) => {
           // Still resolve on error during close
           resolve();
         });

--- a/src/renderer/src/model/App.tsx
+++ b/src/renderer/src/model/App.tsx
@@ -56,12 +56,6 @@ export enum MainPanes {
   LOGGING,
 }
 
-const tipsToDisplayOnStartup = [
-  'TIP: Use Ctrl-Shift-C to copy text \nfrom the terminal, and Ctrl-Shift-V to paste.',
-  'TIP: Change the type of data displayed between ASCII, HEX and other number types in Settings → RX Settings.',
-  'TIP: Press Ctrl-Shift-B to send the "break" signal.',
-];
-
 /**
  * Returns true if the keyboard event originated from an editable element (input, textarea,
  * select, or contenteditable). Used to suppress plain-letter app shortcuts while the user
@@ -274,11 +268,6 @@ export class App {
    */
   async onAppUiLoaded() {
     // Auto-reconnection on startup is now handled through the PortSettings selectedSerialPort
-
-    // Send 1 random tip to snackbar on app load
-    // Choose random tip from array
-    // const randomIndex = Math.floor(Math.random() * tipsToDisplayOnStartup.length);
-    // this.snackbar.sendToSnackbar(tipsToDisplayOnStartup[randomIndex], 'info');
   }
 
   // Serial port connection and auto-reconnection is now handled through PortSettings
@@ -286,7 +275,6 @@ export class App {
   setCloseSettingsDialogOnPortOpenOrClose(trueFalse: boolean) {
     this.closeSettingsDialogOnPortOpenOrClose = trueFalse;
   }
-
 
   /**
    * Starts the rate calculation timer.
@@ -382,7 +370,6 @@ export class App {
    * the main thread's busy vs idle time including React rendering.
    */
   private startCpuMonitoring() {
-    let lastFrameTime = performance.now();
     let frameStartTime = performance.now();
     let busyTime = 0;
     let measurementStartTime = performance.now();
@@ -470,7 +457,7 @@ export class App {
     });
 
     // Update not available
-    electronAPI.updater.onUpdateNotAvailable((updateInfo: any) => {
+    electronAPI.updater.onUpdateNotAvailable((_updateInfo: any) => {
       console.log('No updates available');
       this.snackbar.sendToSnackbar('No updates available. You are running the latest version.', 'info');
     });
@@ -755,7 +742,6 @@ export class App {
     }
   }
 
-
   /**
    * Run performance tests to measure baseline performance and identify bottlenecks
    */
@@ -770,8 +756,6 @@ export class App {
   getPerformanceReport(): string {
     return this.performanceMonitor.getPerformanceReport();
   }
-
-
 
   /** Central place which handles all key pressed in the app.
    * This includes:
@@ -914,19 +898,13 @@ export class App {
       }
     }
 
-    let clipboardText = '';
-    if (selectionInfo !== null) {
-      // Copy the text from the start node to the end node (NOTE: not the same as
-      // the anchor and focus node if the user clicked at the end and released at the start)
-      clipboardText = this.extractClipboardTextFromTerminal(selectionInfo, terminalSelectionWasIn!);
-    } else {
-      // Since selection is not fully contained within a single terminal pane,
-      // do a basic toString() copy of the text to the clipboard
-      // Do we need to await the promise?
-      // WARNING: As per spec at: https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext
-      //   On Windows replace `\n` characters with `\r\n` in data before creating textBlob
-      clipboardText = selection.toString();
-    }
+    // Selection lives in one terminal pane = walk it ourselves; otherwise
+    // fall back to a plain `toString()` of the live DOM selection.
+    // WARNING: As per spec at https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext,
+    //   on Windows we should replace `\n` with `\r\n` before creating a textBlob.
+    const clipboardText = selectionInfo !== null
+      ? this.extractClipboardTextFromTerminal(selectionInfo, terminalSelectionWasIn!)
+      : selection.toString();
 
     navigator.clipboard.writeText(clipboardText);
     // Create toast telling user that text was copied to clipboard

--- a/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
@@ -38,7 +38,10 @@ function updateAndCompare(savedAppData: any) {
   const appDataManager = new AppDataManager(app);
 
   const savedAppVersion = savedAppData.version;
-  let {appData: savedAndUpdatedAppData, wasChanged} = appDataManager._updateAppData(savedAppData);
+  // Split out of one destructure: `savedAndUpdatedAppData` is reassigned
+  // below by `userSpecificReplacer`, but `wasChanged` is only read.
+  const { appData: initialAppData, wasChanged } = appDataManager._updateAppData(savedAppData);
+  let savedAndUpdatedAppData = initialAppData;
   let latestCorrectAppData = new AppData();
   const latestAppDataVersion = latestCorrectAppData.version;
   // v10 adds a ["settings"]["logSettings"]["logDirectory"] path in each profile which is specific to the user's machine because it the default directory

--- a/src/renderer/src/model/AppDataManager/AppDataManager.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.ts
@@ -220,18 +220,16 @@ export class AppDataManager {
     let snackbarMessage = `Profile "${profile.name}" loaded.`;
     let snackbarVariant: VariantType = 'success';
     if (profileLastUsedPortPath == '{}') {
-      weNeedToConnect = false;
+      // No connection info to act on — leave default `false`.
     } else if (profileLastUsedPortPath === currentPortPath) {
-      // Same serial port, no need to disconnect and connect
-      // Note there is a chance we are not connected to the right one due to
-      // ambiguity...but if already connected it is a better user experience to
-      // not disconnect on the high chance it is the correct port
-      weNeedToConnect = false;
+      // Same serial port, no need to disconnect and connect.
+      // There is a chance we are not connected to the right one due to
+      // ambiguity, but if already connected it is a better user experience to
+      // not disconnect on the high chance it is the correct port.
       snackbarMessage += '\nAlready connected port matches one specified in profile. Leaving port connected.';
     } else {
       // They are both different and the profile one is non-empty. Check to see if the profile ports is available
       log.info('Port infos are both different and non-empty. Checking if ports are available...');
-      // const availablePorts = await navigator.serial.getPorts();
       const availablePortsResult = await window.electronAPI.serial.listPorts();
       if (!availablePortsResult.success) {
         throw new Error('Failed to list available ports.');
@@ -241,16 +239,13 @@ export class AppDataManager {
 
       if (matchedAvailablePorts.length === 0) {
         // The profile port is not available
-        weNeedToConnect = false;
         snackbarMessage += '\nNo available port matches the profile port info. No connecting to any.';
         snackbarVariant = 'warning';
       } else if (matchedAvailablePorts.length === 1) {
         // The profile port is available
         weNeedToConnect = true;
       } else {
-        // There are multiple ports that match the profile port, too ambiguous, do
-        // not connect to any
-        weNeedToConnect = false;
+        // Multiple ports match, ambiguous — don't connect to any.
         snackbarMessage += '\nMultiple available ports info match the profile port info (ambiguous). Not connecting to any.';
         snackbarVariant = 'warning';
       }

--- a/src/renderer/src/model/AppDataManager/DataClasses/MacroControllerData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/MacroControllerData.ts
@@ -11,7 +11,7 @@ export class MacroControllerData {
     // saved config from local storage
     this.macroConfigs = [];
     for (let i = 0; i < NUM_MACROS; i++) {
-      let macroConfig = new MacroDataV1();
+      const macroConfig = new MacroDataV1();
       this.macroConfigs.push(macroConfig);
     }
     this.macroConfigs[0].data = 'Hello\\n';

--- a/src/renderer/src/model/ConnController/BluetoothLEController.ts
+++ b/src/renderer/src/model/ConnController/BluetoothLEController.ts
@@ -235,7 +235,7 @@ export class BluetoothLEController {
    * Returns the list of discovered Bluetooth devices, filtered and sorted according to current settings.
    */
   get sortedAndFilteredDiscoveredBluetoothDevices(): SerializableBluetoothDeviceWithMetadata[] {
-    let devices = this.filteredDiscoveredBluetoothDevices;
+    const devices = this.filteredDiscoveredBluetoothDevices;
 
     // If no sort column is set, return unsorted
     if (!this.sortColumn) {
@@ -338,7 +338,7 @@ export class BluetoothLEController {
     let index = this.discoveredBluetoothDevices.findIndex(deviceInList => deviceInList.nobleData.id === device.id);
     if (index !== -1) {
       // Device already exists. Update specific fields if they have not been set before
-      let deviceInList = this.discoveredBluetoothDevices[index];
+      const deviceInList = this.discoveredBluetoothDevices[index];
       if (deviceInList.nobleData.advertisement.localName === '') {
         deviceInList.nobleData.advertisement.localName = device.advertisement.localName;
       }
@@ -358,7 +358,7 @@ export class BluetoothLEController {
     }
     // The following code gets run no matter if the device is already in the list or not
 
-    let deviceInList = this.discoveredBluetoothDevices[index];
+    const deviceInList = this.discoveredBluetoothDevices[index];
     // Add some additional metadata - detect which serial protocols this device supports
     for (const protocol of bluetoothLESerialProtocols) {
       if (deviceInList.nobleData.advertisement.serviceUuids.includes(protocol.serviceUuid)) {

--- a/src/renderer/src/model/ConnController/ConnController.ts
+++ b/src/renderer/src/model/ConnController/ConnController.ts
@@ -628,7 +628,6 @@ export class ConnController {
   }
 
   stopWaitingToReopenPort() {
-    const connectionType = this.app.settings.portConfiguration.connectionType;
     // Bluetooth logic is in the BluetoothLEController, for other connection types the logic is in this class.
     if (this.app.settings.portConfiguration.connectionType === ConnectionType.BLUETOOTH_LE) {
       this.bluetoothLEController.stopPollingForReconnection();

--- a/src/renderer/src/model/FakePorts/FakePortsController.tsx
+++ b/src/renderer/src/model/FakePorts/FakePortsController.tsx
@@ -56,7 +56,7 @@ export default class FakePortsController {
         () => {
           const intervalId = setInterval(() => {
             const textToSend = 'Hello, world!\n';
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -83,7 +83,7 @@ export default class FakePortsController {
         () => {
           const intervalId = setInterval(() => {
             const textToSend = 'Hello, world!\n';
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -110,7 +110,7 @@ export default class FakePortsController {
         () => {
           const intervalId = setInterval(() => {
             const textToSend = 'Hello, world!\n';
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -137,7 +137,7 @@ export default class FakePortsController {
         () => {
           const intervalId = setInterval(() => {
             const textToSend = 'Hello, world!\n';
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -165,7 +165,7 @@ export default class FakePortsController {
           const intervalId = setInterval(() => {
             for (let i = 0; i < 20; i++) {
               const textToSend = 'Hello, world!\n';
-              let bytesToSend = [];
+              const bytesToSend = [];
               for (let i = 0; i < textToSend.length; i++) {
                 bytesToSend.push(textToSend.charCodeAt(i));
               }
@@ -193,7 +193,7 @@ export default class FakePortsController {
         () => {
           for (let i = 0; i < 200; i++) {
             const textToSend = `${i}\n`;
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -201,7 +201,7 @@ export default class FakePortsController {
           }
           return null;
         },
-        (intervalId: NodeJS.Timeout | null) => {
+        (_intervalId: NodeJS.Timeout | null) => {
           // Do nothing
         }
       )
@@ -219,7 +219,7 @@ export default class FakePortsController {
           const strings = ['pass\n', 'fail\n'];
           const intervalId = setInterval(() => {
             const textToSend = strings[stringIdx];
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -253,7 +253,7 @@ export default class FakePortsController {
           const strings = ['\x1b[31mred', '\x1b[32mgreen'];
           const intervalId = setInterval(() => {
             const textToSend = strings[stringIdx];
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -357,7 +357,7 @@ export default class FakePortsController {
           ];
           const intervalId = setInterval(() => {
             const textToSend = strings[stringIdx];
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -390,13 +390,8 @@ export default class FakePortsController {
           let sendIdx = 0;
 
           const intervalId = setInterval(() => {
-            let textToSend = '';
-            if (sendIdx < 50) {
-              textToSend = `Line ${sendIdx}\n`;
-            } else {
-              textToSend = '\x1b[1J';
-            }
-            let bytesToSend = [];
+            const textToSend = sendIdx < 50 ? `Line ${sendIdx}\n` : '\x1b[1J';
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -435,7 +430,7 @@ export default class FakePortsController {
             } else {
               textToSend = '\x1b[2J';
             }
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -471,7 +466,7 @@ export default class FakePortsController {
           }
           textToSend += '\x1b[2J';
 
-          let bytesToSend = [];
+          const bytesToSend = [];
           for (let i = 0; i < textToSend.length; i++) {
             bytesToSend.push(textToSend.charCodeAt(i));
           }
@@ -497,7 +492,7 @@ export default class FakePortsController {
         () => {
           const intervalId = setInterval(() => {
             const textToSend = generateRandomString(80) + '\n';
-            let bytesToSend = [];
+            const bytesToSend = [];
             for (let i = 0; i < textToSend.length; i++) {
               bytesToSend.push(textToSend.charCodeAt(i));
             }
@@ -1175,7 +1170,6 @@ export default class FakePortsController {
           }
 
           let secondCounter = 0;
-          let sampleBatch = 0;
 
           // Single timer that fires every second
           const intervalId = setInterval(() => {
@@ -1217,8 +1211,6 @@ export default class FakePortsController {
               app.parseRxData(new TextEncoder().encode(`$NT:GPH:ADD_DATA,trace=phase_a,data=[${phaseAData.join(',')}];\n`));
               app.parseRxData(new TextEncoder().encode(`$NT:GPH:ADD_DATA,trace=phase_b,data=[${phaseBData.join(',')}];\n`));
               app.parseRxData(new TextEncoder().encode(`$NT:GPH:ADD_DATA,trace=phase_c,data=[${phaseCData.join(',')}];\n`));
-
-              sampleBatch++;
             }
           }, 1000); // Fire every second
 

--- a/src/renderer/src/model/Graphing/Graphing.ts
+++ b/src/renderer/src/model/Graphing/Graphing.ts
@@ -1,5 +1,4 @@
 import { makeAutoObservable } from 'mobx';
-import Validator from 'validatorjs';
 import { z } from 'zod';
 
 import SnackbarController from 'src/model/SnackbarController/SnackbarController';
@@ -156,7 +155,6 @@ class Graphing {
 
 	customValueSeparator = new ApplyableTextField(',', z.string());
 
-
 	/**
 	 * Whether to clear existing plot data when new values arrive.
 	 * Only applicable when multipleValuesPerBuffer is enabled.
@@ -268,7 +266,6 @@ class Graphing {
 		this._saveConfig();
 	}
 
-
 	setClearPlotOnNewValues = (value: boolean) => {
 		this.clearPlotOnNewValues = value;
 		this._saveConfig();
@@ -314,7 +311,7 @@ class Graphing {
 
 		for (let i = 0; i < data.length; i++) {
 			// Convert byte into a character
-			let char = String.fromCharCode(data[i]);
+			const char = String.fromCharCode(data[i]);
 
 			// Advanced mode: stream parser for $NT-prefixed commands terminated by ';' outside of quotes
 			if (this.detectionMode === DetectionMode.ADVANCED_CMD) {
@@ -971,7 +968,7 @@ class Graphing {
 	}
 
 	_saveConfig = () => {
-		let config = this.appDataManager.appData.currentAppConfig.settings.graphingSettings;
+		const config = this.appDataManager.appData.currentAppConfig.settings.graphingSettings;
 
 		config.graphingEnabled = this.graphingEnabled;
 		config.processingTrigger = this.processingTrigger;
@@ -997,7 +994,7 @@ class Graphing {
 	};
 
 	_loadConfig = () => {
-		let configToLoad = this.appDataManager.appData.currentAppConfig.settings.graphingSettings;
+		const configToLoad = this.appDataManager.appData.currentAppConfig.settings.graphingSettings;
 
 		this.graphingEnabled = configToLoad.graphingEnabled;
 		this.processingTrigger = configToLoad.processingTrigger;

--- a/src/renderer/src/model/Logging/Logging.ts
+++ b/src/renderer/src/model/Logging/Logging.ts
@@ -1,5 +1,5 @@
 import { makeAutoObservable, runInAction, toJS } from 'mobx';
-import { ZodString, z } from 'zod';
+import { z } from 'zod';
 
 import { App } from 'src/model/App';
 import { ApplyableTextField } from 'src/view/Components/ApplyableTextField';
@@ -104,7 +104,7 @@ export default class Logging {
       // Initialize the ApplyableTextField for custom filename
       this.customFileName = new ApplyableTextField(
         logSettings.customFileName,
-        z.string().min(1).regex(new RegExp(/^[\w,\s\.-]+$/), 'Filename should contain only alphanumeric characters, spaces, periods, and dashes.'),
+        z.string().min(1).regex(new RegExp(/^[\w,\s.-]+$/), 'Filename should contain only alphanumeric characters, spaces, periods, and dashes.'),
       );
 
       // Set up a listener to save custom filename changes back to profile

--- a/src/renderer/src/model/Performance/DataGenerator.ts
+++ b/src/renderer/src/model/Performance/DataGenerator.ts
@@ -18,13 +18,14 @@ export class DataGenerator {
         }
         break;
 
-      case 'repeated':
+      case 'repeated': {
         // Repeating pattern: "Hello World!\n"
         const message = "Hello World!\n";
         for (let i = 0; i < numBytes; i++) {
           data[i] = message.charCodeAt(i % message.length);
         }
         break;
+      }
 
       case 'mixed':
         // Mix of text, numbers, and control characters
@@ -192,7 +193,7 @@ export class DataGenerator {
         }
         break;
 
-      case 'float32':
+      case 'float32': {
         // Generate float32 values (4 bytes each)
         const floatArray = new Float32Array(Math.floor(numBytes / 4));
         for (let i = 0; i < floatArray.length; i++) {
@@ -200,6 +201,7 @@ export class DataGenerator {
         }
         data.set(new Uint8Array(floatArray.buffer));
         break;
+      }
     }
 
     return data;

--- a/src/renderer/src/model/Performance/PerformanceTester.ts
+++ b/src/renderer/src/model/Performance/PerformanceTester.ts
@@ -1,6 +1,5 @@
 import { App, MainPanes } from '../App';
 import DataGenerator from './DataGenerator';
-import PerformanceMonitor from './PerformanceMonitor';
 import { DetectionMode } from '../Graphing/Graphing';
 
 /**
@@ -244,8 +243,8 @@ export class PerformanceTester {
 
     const startTime = Date.now();
     let totalBytesProcessed = 0;
-    let processingTimes: number[] = [];
-    let frameRates: number[] = [];
+    const processingTimes: number[] = [];
+    const frameRates: number[] = [];
 
     // Create data stream
     const dataStream = DataGenerator.createDataStream(

--- a/src/renderer/src/model/SelectionController/SelectionController.ts
+++ b/src/renderer/src/model/SelectionController/SelectionController.ts
@@ -83,7 +83,7 @@ export class SelectionController {
    */
   static selectTerminalText(startRowId: string, startColIdx: number, endRowId: string, endColIdx: number) {
     // console.log('Selecting text from row:', startRowId, 'column:', startColIdx, 'to row:', endRowId, 'column:', endColIdx);
-    let selection = window.getSelection();
+    const selection = window.getSelection();
     if (selection === null) {
       return false;
     }
@@ -254,34 +254,14 @@ export class SelectionController {
       }
     }
 
-    let firstRowId = '';
-    let firstRowSpanIndex = 0;
-    let firstRowOffset = 0;
-    let firstRowColIdx = 0;
-    let lastRowId = '';
-    let lastRowSpanIndex = 0;
-    let lastRowOffset = 0;
-    let lastRowColIdx = 0;
-    if (isSelectionForwards) {
-      firstRowId = anchorRowId;
-      firstRowSpanIndex = anchorSpanIndexInRow;
-      firstRowOffset = anchorOffset;
-      firstRowColIdx = anchorColIdx;
-      lastRowId = focusRowId;
-      lastRowSpanIndex = focusSpanIndexInRow;
-      lastRowOffset = focusOffset;
-      lastRowColIdx = focusColIdx;
-    } else {
-      // Invert everything
-      firstRowId = focusRowId;
-      firstRowSpanIndex = focusSpanIndexInRow;
-      firstRowOffset = focusOffset;
-      firstRowColIdx = focusColIdx;
-      lastRowId = anchorRowId;
-      lastRowSpanIndex = anchorSpanIndexInRow;
-      lastRowOffset = anchorOffset;
-      lastRowColIdx = anchorColIdx;
-    }
+    const firstRowId = isSelectionForwards ? anchorRowId : focusRowId;
+    const firstRowSpanIndex = isSelectionForwards ? anchorSpanIndexInRow : focusSpanIndexInRow;
+    const firstRowOffset = isSelectionForwards ? anchorOffset : focusOffset;
+    const firstRowColIdx = isSelectionForwards ? anchorColIdx : focusColIdx;
+    const lastRowId = isSelectionForwards ? focusRowId : anchorRowId;
+    const lastRowSpanIndex = isSelectionForwards ? focusSpanIndexInRow : anchorSpanIndexInRow;
+    const lastRowOffset = isSelectionForwards ? focusOffset : anchorOffset;
+    const lastRowColIdx = isSelectionForwards ? focusColIdx : anchorColIdx;
 
 
     return new SelectionInfo(

--- a/src/renderer/src/model/Settings/DisplaySettings/DisplaySettings.ts
+++ b/src/renderer/src/model/Settings/DisplaySettings/DisplaySettings.ts
@@ -140,7 +140,7 @@ export default class DisplaySettings {
    * Save the relevant settings from this class into the current app config in the profile manager.
    */
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.settings.displaySettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.displaySettings;
 
     config.charSizePx = this.charSizePx.appliedValue;
     config.verticalRowPaddingPx = this.verticalRowPaddingPx.appliedValue;
@@ -164,7 +164,7 @@ export default class DisplaySettings {
    * Load the relevant settings from the current app config in the profile manager into this class.
    */
   _loadConfig = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.displaySettings;
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.displaySettings;
 
     this.charSizePx.setDispValue(configToLoad.charSizePx.toString());
     this.charSizePx.apply({notify: false});

--- a/src/renderer/src/model/Settings/GeneralSettings/GeneralSettings.ts
+++ b/src/renderer/src/model/Settings/GeneralSettings/GeneralSettings.ts
@@ -77,7 +77,7 @@ export default class GeneralSettings {
   };
 
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.settings.generalSettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.generalSettings;
 
     config.whenPastingOnWindowsReplaceCRLFWithLF = this.whenPastingOnWindowsReplaceCRLFWithLF;
     config.whenCopyingToClipboardDoNotAddLFIfRowWasCreatedDueToWrapping = this.whenCopyingToClipboardDoNotAddLFIfRowWasCreatedDueToWrapping;
@@ -86,7 +86,7 @@ export default class GeneralSettings {
   };
 
   _loadConfig = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.generalSettings;
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.generalSettings;
 
     this.whenPastingOnWindowsReplaceCRLFWithLF = configToLoad.whenPastingOnWindowsReplaceCRLFWithLF;
     this.whenCopyingToClipboardDoNotAddLFIfRowWasCreatedDueToWrapping = configToLoad.whenCopyingToClipboardDoNotAddLFIfRowWasCreatedDueToWrapping;

--- a/src/renderer/src/model/Settings/PortSettings/PortSettings.ts
+++ b/src/renderer/src/model/Settings/PortSettings/PortSettings.ts
@@ -439,7 +439,7 @@ export class PortSettings {
   };
 
   _loadConfigInner = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.portSettings
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.portSettings
 
     // At this point we are confident that the deserialized config matches what
     // this classes config object wants, so we can go ahead and update.
@@ -484,7 +484,7 @@ export class PortSettings {
 
   _saveConfig = () => {
     if (this._isLoading) return;
-    let config = this.profileManager.appData.currentAppConfig.settings.portSettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.portSettings;
 
     config.baudRate = this.baudRate;
     config.numDataBits = this.numDataBits;

--- a/src/renderer/src/model/Settings/ProfileSettings/ProfileSettings.ts
+++ b/src/renderer/src/model/Settings/ProfileSettings/ProfileSettings.ts
@@ -86,7 +86,7 @@ export default class ProfilesSettings {
     if (this.selectedProfiles.length !== 1) {
       throw new Error('Expected there to be one profile selected.');
     }
-    let selectedProfileIdx = this.selectedProfiles[0];
+    const selectedProfileIdx = this.selectedProfiles[0];
     await this.profileManager.applyProfileToApp(selectedProfileIdx as number);
   };
 
@@ -97,7 +97,7 @@ export default class ProfilesSettings {
     if (this.selectedProfiles.length !== 1) {
       throw new Error('Expected there to be one profile selected.');
     }
-    let selectedProfileIdx = this.selectedProfiles[0];
+    const selectedProfileIdx = this.selectedProfiles[0];
     this.profileManager.saveCurrentAppConfigToProfile(selectedProfileIdx as number);
   }
 
@@ -105,7 +105,7 @@ export default class ProfilesSettings {
     if (this.selectedProfiles.length !== 1) {
       throw new Error('Expected there to be one profile selected.');
     }
-    let selectedProfileIdx = this.selectedProfiles[0];
+    const selectedProfileIdx = this.selectedProfiles[0];
     this.profileManager.deleteProfile(selectedProfileIdx as number);
   }
 }

--- a/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
+++ b/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
@@ -183,7 +183,7 @@ export default class RxSettings {
   }
 
   _loadConfig = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.rxSettings
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.rxSettings
 
     /**
      * How to interpret the received data from the serial port.
@@ -243,7 +243,7 @@ export default class RxSettings {
   };
 
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.settings.rxSettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.rxSettings;
     config.dataType = this.dataType;
 
     // ASCII-SPECIFIC SETTINGS

--- a/src/renderer/src/model/Settings/SoundsSettings/SoundsSettings.ts
+++ b/src/renderer/src/model/Settings/SoundsSettings/SoundsSettings.ts
@@ -22,7 +22,7 @@ export default class SoundsSettings {
   };
 
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.settings.soundsSettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.soundsSettings;
 
     config.playSoundsOnPassFail = this.playSoundsOnPassFail;
 
@@ -30,7 +30,7 @@ export default class SoundsSettings {
   };
 
   _loadConfig = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.soundsSettings;
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.soundsSettings;
 
     this.playSoundsOnPassFail = configToLoad.playSoundsOnPassFail;
   };

--- a/src/renderer/src/model/Settings/TxSettings/TxSettings.ts
+++ b/src/renderer/src/model/Settings/TxSettings/TxSettings.ts
@@ -66,7 +66,7 @@ export default class TxSettings {
   }
 
   _loadConfig = () => {
-    let configToLoad = this.profileManager.appData.currentAppConfig.settings.txSettings;
+    const configToLoad = this.profileManager.appData.currentAppConfig.settings.txSettings;
 
     this.enterKeyPressBehavior = configToLoad.enterKeyPressBehavior;
     this.backspaceKeyPressBehavior = configToLoad.backspaceKeyPressBehavior;
@@ -77,7 +77,7 @@ export default class TxSettings {
   };
 
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.settings.txSettings;
+    const config = this.profileManager.appData.currentAppConfig.settings.txSettings;
 
     config.enterKeyPressBehavior = this.enterKeyPressBehavior;
     config.backspaceKeyPressBehavior = this.backspaceKeyPressBehavior;

--- a/src/renderer/src/model/Terminals/RightDrawer/Macros/Macro.spec.ts
+++ b/src/renderer/src/model/Terminals/RightDrawer/Macros/Macro.spec.ts
@@ -5,103 +5,103 @@ import { Macro, MacroDataType, TxStepBreak, TxStepData } from './Macro';
 describe('macro tests', () => {
 
   test('basic ascii to bytes', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setData('a');
     macro.setSendOnEnterValueForEveryNewLineInTextBox(true);
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([97, 10]));
   });
 
   test('new line converted to \n', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setData('a\nb');
     macro.setSendOnEnterValueForEveryNewLineInTextBox(true);
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([97, 10, 98, 10]));
   });
 
   test('new line converted to \r\n', () => {
-    let macro = new Macro('M1', () => '\r\n');
+    const macro = new Macro('M1', () => '\r\n');
     macro.setData('a\nb');
     macro.setSendOnEnterValueForEveryNewLineInTextBox(true);
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([97, 13, 10, 98, 13, 10]));
   });
 
   test('new line converted to \r', () => {
-    let macro = new Macro('M1', () => '\r');
+    const macro = new Macro('M1', () => '\r');
     macro.setData('a\nb');
     macro.setSendOnEnterValueForEveryNewLineInTextBox(true);
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([97, 13, 98, 13]));
   });
 
   test('basic hex', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00');
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([0]));
   });
 
   test('two bytes of hex', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('0001');
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([0, 1]));
   });
 
   test('two bytes of hex with space', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00 01');
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([0, 1]));
   });
 
   test('two bytes of hex with new lines', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00\n01');
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([0, 1]));
   });
 
   test('make sure odd number of hex chars throws error', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('abc');
 
@@ -109,19 +109,19 @@ describe('macro tests', () => {
   });
 
   test('complicated hex works', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00 ff AB 32\n    689\n1');
 
     const txSequence = macro.dataToTxSequence();
     expect(txSequence.steps.length).toBe(1);
-    let step = txSequence.steps[0] as TxStepData;
+    const step = txSequence.steps[0] as TxStepData;
     expect(step).toBeInstanceOf(TxStepData);
     expect(step.data).toStrictEqual(Uint8Array.from([0x00, 0xFF, 0xAB, 0x32, 0x68, 0x91]));
   });
 
   test('send break for hex works with 2 lines', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00\n01');
     macro.setSendBreakAtEndOfEveryLineOfHex(true);
@@ -131,33 +131,33 @@ describe('macro tests', () => {
 
     // Step 1
     {
-      let step = txSequence.steps[0] as TxStepData;
+      const step = txSequence.steps[0] as TxStepData;
       expect(step).toBeInstanceOf(TxStepData);
       expect(step.data).toStrictEqual(Uint8Array.from([0x00]));
     }
 
     // Step 2
     {
-      let step = txSequence.steps[1] as TxStepBreak;
+      const step = txSequence.steps[1] as TxStepBreak;
       expect(step).toBeInstanceOf(TxStepBreak);
     }
 
     // Step 3
     {
-      let step = txSequence.steps[2] as TxStepData;
+      const step = txSequence.steps[2] as TxStepData;
       expect(step).toBeInstanceOf(TxStepData);
       expect(step.data).toStrictEqual(Uint8Array.from([0x01]));
     }
 
     // Step 4
     {
-      let step = txSequence.steps[3] as TxStepBreak;
+      const step = txSequence.steps[3] as TxStepBreak;
       expect(step).toBeInstanceOf(TxStepBreak);
     }
   });
 
   test('send break and hex throws error if any line is not valid hex', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('00\n0\n02'); // Forget the 1 in the 2nd line
     macro.setSendBreakAtEndOfEveryLineOfHex(true);
@@ -166,13 +166,13 @@ describe('macro tests', () => {
   });
 
   test('toConfig() and fromConfig() work', () => {
-    let macro = new Macro('M1', () => '\n');
+    const macro = new Macro('M1', () => '\n');
     macro.setDataType(MacroDataType.HEX);
     macro.setData('1234');
     const macroConfig = macro.toConfig();
 
     // Create new macro
-    let newMacro = new Macro('M1', () => '\n');
+    const newMacro = new Macro('M1', () => '\n');
     newMacro.loadConfig(macroConfig);
 
     expect(newMacro.data).toBe(macro.data);

--- a/src/renderer/src/model/Terminals/RightDrawer/Macros/Macro.ts
+++ b/src/renderer/src/model/Terminals/RightDrawer/Macros/Macro.ts
@@ -103,7 +103,7 @@ export class Macro {
    * @returns The Uint8Array representation of the data.
    */
   dataToTxSequence = (): TxSequence => {
-    let txSequence = new TxSequence();
+    const txSequence = new TxSequence();
     if (this.dataType === MacroDataType.ASCII) {
       // Replace all instances of LF with the newLinesChar
       // NOTE: This has to be done before JSON.parse() is called below, otherwise the LF that
@@ -111,7 +111,7 @@ export class Macro {
       // let str = this.data;
 
       // Split the string into lines
-      let lines = this.data.split('\n');
+      const lines = this.data.split('\n');
 
       // Loop through each line
       let processedStr = '';
@@ -124,7 +124,7 @@ export class Macro {
           // JSON.parse will throw a SyntaxError if the string is not valid JSON
           try {
             processedStr += JSON.parse(`"${lines[i]}"`);
-          } catch (e) {
+          } catch {
             throw new Error('Line failed during JSON.parse(). Likely has unfinished escape codes or unescaped quotes.');
           }
         } else {
@@ -139,7 +139,7 @@ export class Macro {
       }
 
       // Convert to Uint8Array
-      let txStepData = new TxStepData(stringToUint8Array(processedStr));
+      const txStepData = new TxStepData(stringToUint8Array(processedStr));
       txSequence.steps.push(txStepData);
     } else if (this.dataType === MacroDataType.HEX) {
       // If "sendEnterValueForEveryNewLineInTextBox" is true, then we need to parse the hex
@@ -176,7 +176,7 @@ export class Macro {
         }
 
         // Convert hex string to Uint8Array
-        let txStepData = new TxStepData(this._hexStringToUint8Array(str));
+        const txStepData = new TxStepData(this._hexStringToUint8Array(str));
         txSequence.steps.push(txStepData);
 
         if (this.sendBreakAtEndOfEveryLineOfHex) {

--- a/src/renderer/src/model/Terminals/RightDrawer/Macros/MacroController.ts
+++ b/src/renderer/src/model/Terminals/RightDrawer/Macros/MacroController.ts
@@ -87,7 +87,7 @@ export class MacroController {
 
   _saveConfig = () => {
 
-    let config = this.app.profileManager.appData.currentAppConfig.terminal.macroController;
+    const config = this.app.profileManager.appData.currentAppConfig.terminal.macroController;
 
     config.macroConfigs = this.macrosArray.map((macro) => {
       return macro.toConfig();
@@ -97,13 +97,13 @@ export class MacroController {
   };
 
   _loadConfig() {
-    let configToLoad = this.app.profileManager.appData.currentAppConfig.terminal.macroController;
+    const configToLoad = this.app.profileManager.appData.currentAppConfig.terminal.macroController;
 
     // If we get here we loaded a valid config. Apply config.
     this.recreateMacros(configToLoad.macroConfigs.length);
     for (let i = 0; i < configToLoad.macroConfigs.length; i++) {
       const macroConfig = configToLoad.macroConfigs[i];
-      let macro = this.macrosArray[i];
+      const macro = this.macrosArray[i];
       macro.loadConfig(macroConfig);
     };
   }

--- a/src/renderer/src/model/Terminals/RightDrawer/RightDrawer.ts
+++ b/src/renderer/src/model/Terminals/RightDrawer/RightDrawer.ts
@@ -68,7 +68,7 @@ export default class RightDrawer {
   };
 
   _saveConfig = () => {
-    let config = this.profileManager.appData.currentAppConfig.terminal.rightDrawer;
+    const config = this.profileManager.appData.currentAppConfig.terminal.rightDrawer;
 
     config.rightDrawerWidth_px = this.drawerWidth_px;
 

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
@@ -635,7 +635,7 @@ export class SingleTerminal {
       if (numberStr === '') {
         numberStr = '1';
       }
-      let numRowsToGoUp = parseInt(numberStr, 10);
+      const numRowsToGoUp = parseInt(numberStr, 10);
       if (Number.isNaN(numRowsToGoUp)) {
         console.error(`Number string in SGR code could not converted into integer. numberStr=${numberStr}.`);
         return;
@@ -725,7 +725,7 @@ export class SingleTerminal {
         for (let charIdx = 0; charIdx < this.cursorPosition[1]; charIdx += 1) {
           currRow.terminalChars[charIdx].char = ' ';
           currRow.terminalChars[charIdx].forCursor = false;
-          currRow.terminalChars[charIdx].style = '';
+          currRow.terminalChars[charIdx].style = {};
         }
       } else if (numberN === 2) {
         // Erase entire screen
@@ -843,7 +843,7 @@ export class SingleTerminal {
       // Add received byte to number array
       this.partialNumberBuffer.push(rxByte);
 
-      let numberAsBigInt = BigInt(0); // This is used for the new line on match feature
+      let numberAsBigInt: bigint; // This is used for the new line on match feature
       let numberStr = ''; // This is used for displaying the number in the terminal
       //========================================================================
       // CREATE NUMBER PART OF STRING
@@ -1029,7 +1029,7 @@ export class SingleTerminal {
       //========================================================================
       if (this.rxSettings.padValues) {
         // If padding is set to automatic, pad to the largest possible value for the selected number type
-        let paddingChar = ' ';
+        let paddingChar: string;
         if (this.rxSettings.paddingCharacter === PaddingCharacter.ZERO) {
           paddingChar = '0';
         } else if (this.rxSettings.paddingCharacter === PaddingCharacter.WHITESPACE) {
@@ -1103,7 +1103,6 @@ export class SingleTerminal {
       // 2) The terminal column width is high enough to fit an entire value in it
       if (this.rxSettings.preventValuesWrappingAcrossRows && this.displaySettings.terminalWidthChars.appliedValue >= numberStr.length) {
         // Create a new terminal row if the hex value will not fit on existing row
-        const currRow = this.terminalRows[this.cursorPosition[0]];
         const numColsLeftOnRow = this.displaySettings.terminalWidthChars.appliedValue - this.cursorPosition[1];
         if (numberStr.length > numColsLeftOnRow) {
           // Move cursor to next row
@@ -1135,7 +1134,6 @@ export class SingleTerminal {
 
       // Add to string to the the terminal
       for (let charIdx = 0; charIdx < numberStr.length; charIdx += 1) {
-        const charCode = numberStr.charCodeAt(charIdx);
         this._maybeAddVisibleByteAndTimestamp(numberStr.charCodeAt(charIdx), direction);
       }
       // Append the hex separator string
@@ -1350,7 +1348,7 @@ export class SingleTerminal {
   _maybeAddVisibleByteAndTimestamp(rxByte: number, direction: DataDirection) {
     const nonVisibleCharDisplayBehavior = this.rxSettings.nonVisibleCharDisplayBehavior;
 
-    let char = '';
+    let char: string;
     if (rxByte >= 0x20 && rxByte <= 0x7e) {
       // Is printable ASCII character, no shifting needed
       char = String.fromCharCode(rxByte);
@@ -1423,7 +1421,7 @@ export class SingleTerminal {
     terminalChar.char = char;
 
     // This stores all classes we wish to apply to the char
-    let classList = [];
+    const classList = [];
 
     // Apply a class indicating the direction of the data
     if (direction === DataDirection.TX) {
@@ -1681,18 +1679,18 @@ export class SingleTerminal {
   /**
    * No longer needed - filteredTerminalRows is now computed automatically
    */
-  _addToFilteredRows(terminalRowToInsert: TerminalRow) {
+  _addToFilteredRows(_terminalRowToInsert: TerminalRow) {
     // This method is no longer needed since filteredTerminalRows is computed
   }
 
   /**
    * No longer needed - filteredTerminalRows is now computed automatically
    */
-  _removeFromFilteredRows(terminalRowToRemove: TerminalRow) {
+  _removeFromFilteredRows(_terminalRowToRemove: TerminalRow) {
     // This method is no longer needed since filteredTerminalRows is computed
   }
 
-  _addOrRemoveRowFromFilteredRows = (rowIdx: number) => {
+  _addOrRemoveRowFromFilteredRows = (_rowIdx: number) => {
     // This method is no longer needed since filteredTerminalRows is computed automatically
   }
 

--- a/src/renderer/src/model/Terminals/Terminals.ts
+++ b/src/renderer/src/model/Terminals/Terminals.ts
@@ -56,13 +56,13 @@ export default class Terminals {
   }
 
   _saveConfig = () => {
-    let config = this.app.profileManager.appData.currentAppConfig.terminal.rightDrawer;
+    const config = this.app.profileManager.appData.currentAppConfig.terminal.rightDrawer;
     config.showRightDrawer = this.showRightDrawer;
     this.app.profileManager.saveAppData();
   };
 
   _loadConfig = () => {
-    let configToLoad = this.app.profileManager.appData.currentAppConfig.terminal.rightDrawer;
+    const configToLoad = this.app.profileManager.appData.currentAppConfig.terminal.rightDrawer;
     this.showRightDrawer = configToLoad.showRightDrawer;
   };
 }

--- a/src/renderer/src/model/Util/SettingsLoader.tsx
+++ b/src/renderer/src/model/Util/SettingsLoader.tsx
@@ -8,7 +8,7 @@ import ApplyableTextField, { ApplyableNumberField } from "src/view/Components/Ap
  * @param configObject The config object to update.
  */
 export function updateConfigFromSerializable(serializedSettings: any, configObject: any) {
-  Object.keys(configObject).forEach(function (key, index) {
+  Object.keys(configObject).forEach(function (key, _index) {
     // console.log('key:', key, 'index:', index);
     // let key1 = key as keyof ConfigV1;
     // console.log(typeof (me.config[key1]));

--- a/src/renderer/src/model/Util/Util.ts
+++ b/src/renderer/src/model/Util/Util.ts
@@ -29,7 +29,7 @@ export function stringToUint8Array(str: string) {
  */
 export function getChildNodeIndex(child: Element | null)
 {
-    var i = 0;
+    let i = 0;
     while ((child = child!.previousElementSibling) != null )
     i++;
 

--- a/src/renderer/src/view/AppView.tsx
+++ b/src/renderer/src/view/AppView.tsx
@@ -23,9 +23,9 @@ import styles from './AppView.module.css';
 import FakePortDialogView from './FakePorts/FakePortDialogView';
 import { useEffect } from 'react';
 import LoggingView from './Logging/LoggingView';
-import { SelectionController, SelectionInfo } from '../model/SelectionController/SelectionController';
+import { SelectionController } from '../model/SelectionController/SelectionController';
 import 'src/model/WindowTypes';
-import { DataType } from 'src/model/Settings/RxSettings/RxSettings';
+
 import { SettingsCategories } from 'src/model/Settings/Settings';
 
 // Create dark theme for MUI
@@ -80,9 +80,7 @@ const connStateToToolbarStatusProperties: { [key in ConnState]: any } = {
   },
 };
 
-interface Props {
-  // app: App;
-}
+// AppView takes no props — it uses the module-level `app` singleton below.
 
 const app = new App();
 
@@ -231,7 +229,7 @@ const PortConfigIndicator = observer(({ app }: { app: App }) => (
 
 const PortStatusIndicator = observer(({ app }: { app: App }) => {
   const getStatusText = (connState: ConnState, connectionType: ConnectionType) => {
-    let connectionTypeName = '';
+    let connectionTypeName: string;
     if (connectionType === ConnectionType.SERIAL_PORT) {
       connectionTypeName = 'Port';
     } else if (connectionType === ConnectionType.SOCKET) {
@@ -289,7 +287,7 @@ const MainPaneSelector = observer(({ app }: { app: App }) => {
   }
 });
 
-const AppView = observer((props: Props) => {
+const AppView = observer(() => {
   useEffect(() => {
     // Initialize the app after it has rendered
     const initFn = async () => {

--- a/src/renderer/src/view/Components/ApplyableTextFieldView.tsx
+++ b/src/renderer/src/view/Components/ApplyableTextFieldView.tsx
@@ -1,22 +1,8 @@
 import React from "react";
-import {
-  Button,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  FormLabel,
-  InputAdornment,
-  InputLabel,
-  MenuItem,
-  Radio,
-  RadioGroup,
-  Select,
-  TextField,
-  TextFieldProps,
-} from "@mui/material";
+import { TextField, TextFieldProps } from "@mui/material";
 import { observer } from "mobx-react-lite";
 
-import ApplyableField, { ApplyableTextField } from "./ApplyableTextField";
+import ApplyableField from "./ApplyableTextField";
 
 interface ModelProps {
   applyableTextField: ApplyableField;

--- a/src/renderer/src/view/Components/BorderedSection.tsx
+++ b/src/renderer/src/view/Components/BorderedSection.tsx
@@ -6,6 +6,9 @@ import { SvgIconTypeMap } from "@mui/material/SvgIcon";
 import { OverridableComponent } from "@mui/material/OverridableComponent";
 
 type BorderedSectionProps = {
+  // MUI's `SvgIconTypeMap` is parameterised on a `{}` props object — that's
+  // their public type signature for "no extra props", not something we choose.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   icon?: OverridableComponent<SvgIconTypeMap<{}, "svg">> & { props: { className?: string } };
   title?: string;
   style?: React.CSSProperties;

--- a/src/renderer/src/view/FakePorts/FakePortDialogView.tsx
+++ b/src/renderer/src/view/FakePorts/FakePortDialogView.tsx
@@ -1,17 +1,4 @@
-import {
-  Button,
-  Checkbox,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-} from '@mui/material';
+import { Button, Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 
 import { App } from '../../model/App';

--- a/src/renderer/src/view/Graphing/GraphingView.tsx
+++ b/src/renderer/src/view/Graphing/GraphingView.tsx
@@ -1,15 +1,4 @@
-import {
-  Button,
-  FormControl,
-  FormControlLabel,
-  InputLabel,
-  MenuItem,
-  Select,
-  Switch,
-  TextField,
-  Tooltip,
-  IconButton,
-} from "@mui/material";
+import { Button, FormControl, FormControlLabel, InputLabel, MenuItem, Select, Switch, Tooltip, IconButton } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { observer } from "mobx-react-lite";
@@ -61,7 +50,7 @@ export default observer((props: Props) => {
 
   // Calculate x-axis label based on x variable source
   const xVarSource = app.graphing.xVarSource;
-  let xVarLabel = "";
+  let xVarLabel: string;
   if (xVarSource === "Received Time") {
     xVarLabel = "Time [s]";
   } else if (xVarSource === "Counter") {
@@ -457,7 +446,6 @@ export default observer((props: Props) => {
               />
             </Tooltip>
           )}
-
 
           {/* CLEAR PLOT ON NEW VALUES */}
           {/* ============================================================== */}

--- a/src/renderer/src/view/Logging/LoggingView.tsx
+++ b/src/renderer/src/view/Logging/LoggingView.tsx
@@ -1,18 +1,4 @@
-import {
-  Button,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  FormLabel,
-  InputLabel,
-  MenuItem,
-  Radio,
-  RadioGroup,
-  Select,
-  Switch,
-  TextField,
-  Tooltip,
-} from "@mui/material";
+import { Button, Checkbox, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, Switch, TextField, Tooltip } from "@mui/material";
 import { observer } from "mobx-react-lite";
 
 import { App } from "src/model/App";

--- a/src/renderer/src/view/Settings/DisplaySettings/DisplaySettingsView.tsx
+++ b/src/renderer/src/view/Settings/DisplaySettings/DisplaySettingsView.tsx
@@ -1,10 +1,9 @@
-import { FormControl, InputAdornment, InputLabel, MenuItem, Select, TextField, Tooltip, Button, FormLabel, Popover, IconButton, Checkbox, FormControlLabel } from '@mui/material';
+import { FormControl, InputAdornment, InputLabel, MenuItem, Select, TextField, Tooltip, Button, FormLabel, IconButton, Checkbox, FormControlLabel } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 
 import { App } from 'src/model/App';
 import ApplyableTextFieldView from 'src/view/Components/ApplyableTextFieldView';
-import BorderedSection from 'src/view/Components/BorderedSection';
 import { DataViewConfiguration, TerminalHeightMode, dataViewConfigEnumToDisplayName } from 'src/model/Settings/DisplaySettings/DisplaySettings';
 import PopoverColorPicker from 'src/view/Components/PopoverColorPicker';
 

--- a/src/renderer/src/view/Settings/GeneralSettings/GeneralSettingsView.tsx
+++ b/src/renderer/src/view/Settings/GeneralSettings/GeneralSettingsView.tsx
@@ -1,9 +1,9 @@
-import { Checkbox, FormControlLabel, Tooltip, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography, Alert, TextField, IconButton, InputAdornment } from "@mui/material";
+import { Checkbox, FormControlLabel, Tooltip, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography, Alert, TextField, IconButton } from "@mui/material";
 import { observer } from "mobx-react-lite";
 import React, { useState, useRef } from "react";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import GeneralSettings from "src/model/Settings/GeneralSettings/GeneralSettings";
-import { App, MainPanes } from "src/model/App";
+import { App } from "src/model/App";
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
 import SpeedIcon from '@mui/icons-material/Speed';

--- a/src/renderer/src/view/Settings/ProfileSettings/ProfileSettingsView.tsx
+++ b/src/renderer/src/view/Settings/ProfileSettings/ProfileSettingsView.tsx
@@ -31,7 +31,7 @@ function ProfileSettingsView(props: Props) {
   ];
 
   // Create rows in profiles table
-  let rows: any = [];
+  const rows: any = [];
   for (let idx = 0; idx < profiles.length; idx++) {
     const profile = profiles[idx];
     const portSettings = profile.rootConfig.settings.portSettings;

--- a/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormLabel, InputAdornment, InputLabel, MenuItem, Radio, RadioGroup, Select, TextField, Tooltip } from '@mui/material';
+import { Checkbox, FormControl, FormControlLabel, FormLabel, InputAdornment, InputLabel, MenuItem, Radio, RadioGroup, Select, Tooltip } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 
 import RxSettings, {

--- a/src/renderer/src/view/Settings/TxSettings/TxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/TxSettings/TxSettingsView.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormLabel, InputAdornment, Radio, RadioGroup, Tooltip } from '@mui/material';
+import { Checkbox, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, Tooltip } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 
 import TxSettings, { BackspaceKeyPressBehavior, DeleteKeyPressBehavior, EnterKeyPressBehavior } from 'src/model/Settings/TxSettings/TxSettings';

--- a/src/renderer/src/view/Terminals/RightDrawer/FlowControlView.tsx
+++ b/src/renderer/src/view/Terminals/RightDrawer/FlowControlView.tsx
@@ -15,7 +15,7 @@ interface FlowControlIndicatorProps {
   active: boolean;
 }
 
-const FlowControlIndicator = ({ label, active }: FlowControlIndicatorProps) => {
+const FlowControlIndicator = ({ active }: FlowControlIndicatorProps) => {
   return (
     <Box
       sx={{

--- a/src/renderer/src/view/Terminals/RightDrawer/MacroRowView.tsx
+++ b/src/renderer/src/view/Terminals/RightDrawer/MacroRowView.tsx
@@ -21,8 +21,8 @@ interface Props {
 export default observer((props: Props) => {
   const { app, macroController, macro, macroIdx } = props;
 
-  let dataTypeShort = "";
-  let dataTypeColor = "";
+  let dataTypeShort: string;
+  let dataTypeColor: string;
   if (macro.dataType === "ASCII") {
     dataTypeShort = "A";
     dataTypeColor = "#FFD700";

--- a/src/renderer/src/view/Terminals/RightDrawer/RightDrawerView.tsx
+++ b/src/renderer/src/view/Terminals/RightDrawer/RightDrawerView.tsx
@@ -24,7 +24,7 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import { OverridableStringUnion } from '@mui/types';
 
 import { App, MainPanes } from '@/model/App';
-import { PortType } from '@/model/ConnController/ConnController';
+
 import MacroView from './MacroRowView';
 import MacroSettingsModalView from './MacroSettingsModalView';
 import ApplyableTextFieldView from '@/view/Components/ApplyableTextFieldView';
@@ -73,7 +73,7 @@ export default observer((props: Props) => {
     <Resizable // This what provides the resizing functionality for the right drawer
       className="box"
       width={rightDrawer.drawerWidth_px}
-      onResize={(e, { node, size, handle }) => {
+      onResize={(_e, { size }) => {
         rightDrawer.setDrawerWidth(size.width);
       }}
       resizeHandles={['w']}

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalChar.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalChar.tsx
@@ -1,10 +1,13 @@
+import React from 'react';
+
 /**
  * Represents a single character in the terminal
  */
 export default class TerminalChar {
   char: string;
 
-  style: {};
+  // Reserved for inline style overrides; empty object by default.
+  style: React.CSSProperties;
 
   className = '';
 

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Tooltip } from '@mui/material';
 import { observer } from 'mobx-react-lite';
-import React, { useRef, ReactElement, useLayoutEffect, useEffect, forwardRef, useMemo } from 'react';
+import React, { useRef, useLayoutEffect, useEffect, forwardRef, useMemo } from 'react';
 import LockIcon from '@mui/icons-material/Lock';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -23,7 +23,7 @@ interface Props {
 interface RowProps {
   data: TerminalRow[]; // This is the array of indexes into the terminalRows array
   index: number; // This is the index into the data array above
-  style: {};
+  style: React.CSSProperties;
 }
 
 export default observer((props: Props) => {
@@ -138,7 +138,7 @@ export default observer((props: Props) => {
   const selection = window.getSelection();
   // Convert the selection (which has pointers to the nodes) into the rows and columns of the terminal
   // that the selection starts and ends at
-  let selectionInfo = SelectionController.getSelectionInfo(selection, terminal.id);
+  const selectionInfo = SelectionController.getSelectionInfo(selection, terminal.id);
 
   // Re-applies the mouseup-cached selection (with clamping for off-screen endpoints).
   // Called from both useLayoutEffect (React re-renders) and onItemsRendered (scroll
@@ -259,7 +259,6 @@ export default observer((props: Props) => {
     ))
   }, []);
 
-
   let scrollLockUnlockIcon;
   if (terminal.scrollLock) {
     scrollLockUnlockIcon = <LockIcon
@@ -301,13 +300,13 @@ export default observer((props: Props) => {
           '--default-tx-color': terminal.defaultTxColor,
           '--default-rx-color': terminal.defaultRxColor,
         } as React.CSSProperties & { [key: string]: string | number }}
-        onFocus={(e) => {
+        onFocus={(_e) => {
           terminal.setIsFocused(true);
         }}
-        onBlur={(e) => {
+        onBlur={(_e) => {
           terminal.setIsFocused(false);
         }}
-        onKeyDown={(e) => {
+        onKeyDown={(_e) => {
           // Key presses now dealt with by global handler in App component
           // terminal.handleKeyDown(e);
         }}

--- a/src/renderer/src/view/Terminals/TerminalsView.tsx
+++ b/src/renderer/src/view/Terminals/TerminalsView.tsx
@@ -1,15 +1,8 @@
 import {
-  Box,
   Button,
   ButtonPropsColorOverrides,
-  FormControl,
-  FormControlLabel,
   IconButton,
   InputAdornment,
-  InputLabel,
-  MenuItem,
-  Select,
-  Switch,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -23,10 +16,9 @@ import { observer } from 'mobx-react-lite';
 import 'react-resizable/css/styles.css';
 
 import { App } from 'src/model/App';
-import { PortType } from '@/model/ConnController/ConnController';
 import { ConnState } from 'src/model/Settings/PortSettings/PortSettings';
 import SingleTerminalView from './SingleTerminal/SingleTerminalView';
-import { DataViewConfiguration, dataViewConfigEnumToDisplayName } from 'src/model/Settings/DisplaySettings/DisplaySettings';
+import { DataViewConfiguration } from 'src/model/Settings/DisplaySettings/DisplaySettings';
 import ApplyableTextFieldView from 'src/view/Components/ApplyableTextFieldView';
 import { portStateToButtonProps } from 'src/view/Components/PortStateToButtonProps';
 import RightDrawerView from './RightDrawer/RightDrawerView';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,4 @@
-import { expect, afterEach, beforeEach, vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 


### PR DESCRIPTION
First focused pass over the lint debt that piled up before ESLint was properly wired (#386). Net: 178 warnings cleared (~63%), zero errors.

## What this PR fixes

| Rule | Before | After | Notes |
|---|---|---|---|
| `prefer-const` | 81 | 0 | All auto-fixable via `eslint --fix` |
| `@typescript-eslint/no-unused-vars` | 67 | 0 | ~37 unused imports stripped; unused args renamed to `_<name>`; genuine dead code deleted |
| `no-useless-assignment` | 20 | 1 | Mostly `let x = ''; if (...) x = 'b'; else x = 'c'` patterns collapsed to ternaries or `let x: T` |
| `@typescript-eslint/no-empty-object-type` | 4 | 0 | `{}` → `React.CSSProperties` for style fields; removed an empty `interface Props {}` |
| `no-case-declarations` | 2 | 0 | Block-wrapped two cases in `DataGenerator` |
| `no-useless-escape` | 1 | 0 | `\.` inside a character class |
| Other small rules | 1 | 0 | Mixed |

Genuine dead code deleted while I was in there: `tipsToDisplayOnStartup` (only referenced in commented-out code), `lastFrameTime` (declared and never read), `bluetoothService` retainer variable (the constructor side-effects are the point), the `sampleBatch++` counter in a fake-port generator, two unused `Validator`/`PerformanceMonitor` imports, etc.

## What's deliberately left

| Rule | Count | Why |
|---|---|---|
| `@typescript-eslint/no-explicit-any` | 93 | Mostly in the IPC bridge (preload) and updater event handlers where `any` reflects real wire untyped-ness. Replacing with `unknown` just pushes validation one frame down. Worth its own focused pass with a real plan (e.g. zod schemas on IPC payloads). |
| `react-hooks/set-state-in-effect` | 2 | Real "you might not need this effect" perf hints in `PopoverColorPicker` and `ConnectionSettingsView`. Each needs careful refactoring of the effect body. |
| `react-hooks/exhaustive-deps` | 6 | Per-case judgement calls. |

## How

Auto-fixable rules ran via `eslint --fix`. The unused-imports cleanup used a temporary Python helper that walked the `eslint --format json` output and edited each `import { ... }` block in place — much faster than 16 file-by-file edits and the script is idempotent. Helper deleted at the end (was only useful for this one batch).

The unused-args rename + dead-code deletion was per-file manual work, since each case wanted a different action (delete vs `_` prefix vs restructure).

## Test plan

- [x] `npx tsc` — clean
- [x] `npm run test:unit` — 141/141 pass
- [x] `npm run lint` — 0 errors, 102 warnings (down from 280)
- [ ] Quick smoke: open a port, scan BLE, verify nothing in the renderer behaves differently. The risky cases were the no-useless-assignment refactors in `AppDataManager.applyProfile` (collapsed `if/else if/else` chains that all assigned the same flag) and `SelectionController.getSelectionInfo` (8 ternaries).

No CHANGELOG entry — internal-only with zero outward impact.