### PR TITLE
Dispose RTT server-log listener on failed connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- **Failed RTT connect attempts no longer multiply log lines on retry.** The `rtt:server-log` listener is registered before `rtt.connect()` to capture startup messages; the catch block didn't dispose it on failure, so each retry stacked another listener and each line was emitted N times after N failures. `ConnController` now calls `disposeConnListeners()` in the RTT failure path.
+
 ## [5.11.2] - 2026-04-27
 
 ### Changed

--- a/src/renderer/src/model/ConnController/ConnController.ts
+++ b/src/renderer/src/model/ConnController/ConnController.ts
@@ -494,6 +494,11 @@ export class ConnController {
         if (!silenceSnackbar) {
           this.app.snackbar.sendToSnackbar(msg, 'error');
         }
+        // Drop any IPC listeners we registered for this attempt (the server-log listener
+        // is registered before connect to capture startup messages). Without this, a
+        // failed attempt leaves the listener attached and the next attempt stacks
+        // another, so each line gets emitted N times after N failures.
+        this.disposeConnListeners();
         showProgressModal(false);
         return false;
       }


### PR DESCRIPTION
## Summary

- Failed RTT connect attempts were leaking the `rtt:server-log` IPC listener. It is registered before `rtt.connect()` so the diagnostic pane captures startup messages, but the catch block never disposed it. Each retry stacked another listener, and because the listener falls back to accepting events when `currentRttConnectionId === null` (true mid-connect), every stale listener also pushed into the log — each line ended up emitted N times after N failures (the "twice, thrice, …" pattern visible in the J-Link Commander Output pane).
- Fix: `ConnController` now calls `disposeConnListeners()` in the RTT failure path, mirroring the socket-reconnect leak fixed in 5.11.2.
- CHANGELOG entry added under Unreleased / Fixed.

## Test plan

- [x] `npx tsc` — clean
- [x] `npm run test:unit` — 141/141 pass
- [ ] Manual: trigger a failed RTT connect (e.g. wrong device name or no probe attached), retry several times, confirm each J-Link Commander Output line appears exactly once per attempt.