### PR TITLE
Refresh tagline and homepage copy for four-transport scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- Homepage and `/app` redirect-page browser titles no longer say "NinjaTerm" twice. Docusaurus auto-appends ` | NinjaTerm` from `siteConfig.title`, so the per-page `Layout` titles now omit the brand prefix (homepage tab is now `An embedded developer's terminal that's got your back | NinjaTerm`).
+- **Tagline + homepage copy refreshed** for four-transport scope (serial, TCP socket, Bluetooth LE, SEGGER RTT). Tagline now "An embedded developer's terminal that's got your back."; homepage hero, browser titles, Docusaurus site tagline, manual intro, README, `<Layout>` SEO description, JSON-LD structured-data description/keywords, root `index.html` meta description, and the body intro paragraph no longer describe NinjaTerm as a serial port terminal.
+
 ### Fixed
 
 - **Failed RTT connect attempts no longer multiply log lines on retry.** The `rtt:server-log` listener is registered before `rtt.connect()` to capture startup messages; the catch block didn't dispose it on failure, so each retry stacked another listener and each line was emitted N times after N failures. `ConnController` now calls `disposeConnListeners()` in the RTT failure path.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="img/logo/v3/github-readme-logo.png" alt="The NinjaTerm logo." height="200px"></p>
 
-#### A serial port terminal that's got your back.
+#### An embedded developer's terminal that's got your back.
 
 <br>
 

--- a/docs/docs/manual.mdx
+++ b/docs/docs/manual.mdx
@@ -2,9 +2,9 @@
 
 ## Getting Started
 
-Welcome to **NinjaTerm** - a serial port terminal that's got your back!
+Welcome to **NinjaTerm** - an embedded developer's terminal that's got your back!
 
-NinjaTerm is an open source and free electron (or web-based) application designed for viewing debug serial port data and sending commands when developing firmware for an embedded device (e.g. microcontroller).
+NinjaTerm is an open source and free electron (or web-based) application designed for viewing debug data and sending commands when developing firmware for an embedded device (e.g. microcontroller). Connect via serial port, TCP socket, Bluetooth LE, or SEGGER RTT.
 
 If you are looking for a serious terminal for continual use, the installable desktop versions are recommended. If you are looking for a quick way to view some serial data without having to install anything, the web-based version is for you!
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'NinjaTerm',
-  tagline: 'A serial port terminal that\'s got your back.',
+  tagline: 'An embedded developer\'s terminal that\'s got your back.',
   favicon: 'img/ninjaterm-logo.png',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future

--- a/docs/src/pages/app.tsx
+++ b/docs/src/pages/app.tsx
@@ -8,7 +8,7 @@ export default function App(): JSX.Element {
   }, []);
 
   return (
-    <Layout title="Redirecting to NinjaTerm Web App...">
+    <Layout title="Redirecting to Web App...">
       <div style={{
         display: 'flex',
         justifyContent: 'center',

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -160,9 +160,9 @@ export default function Home(): JSX.Element {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Cross-platform (Web-based)',
     description:
-      'NinjaTerm is a free, open-source, web-based serial port terminal for embedded developers. View debug data, send commands, and streamline your embedded development workflow with features like ANSI escape code support, graphing, logging, filtering and more.',
+      'NinjaTerm is a free, open-source, cross-platform terminal for embedded developers. Connect via serial port, TCP socket, Bluetooth LE, or SEGGER RTT. View debug data, send commands, and streamline your embedded development workflow with features like ANSI escape code support, graphing, logging, filtering and more.',
     keywords:
-      'NinjaTerm, Ninja Term, terminal, serial port, serial terminal, web serial, developer tool, embedded, IoT, microcontroller, firmware, debug, open source, serial monitor, graphing, logging, filtering, smart scrolling, number types',
+      'NinjaTerm, Ninja Term, terminal, serial port, serial terminal, TCP socket, Bluetooth LE, SEGGER RTT, J-Link, web serial, developer tool, embedded, IoT, microcontroller, firmware, debug, open source, serial monitor, graphing, logging, filtering, smart scrolling, number types',
     url: 'https://ninjaterm.mbedded.ninja/',
     potentialAction: {
       '@type': 'ViewAction',
@@ -177,8 +177,8 @@ export default function Home(): JSX.Element {
 
   return (
     <Layout
-      title="NinjaTerm - A serial port terminal that's got your back"
-      description="NinjaTerm is a free, open-source serial port terminal for embedded developers with features like ANSI escape codes, graphing, logging, and more."
+      title="An embedded developer's terminal that's got your back"
+      description="NinjaTerm is a free, open-source terminal for embedded developers — supports serial ports, TCP sockets, Bluetooth LE, and SEGGER RTT, with features like ANSI escape codes, graphing, logging, and more."
     >
       <Head>
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
@@ -192,7 +192,7 @@ export default function Home(): JSX.Element {
       <Grid size={12} sx={{ height: '20px' }} />
       <Grid size={12} sx={{ display: 'flex', justifyContent: 'center' }}>
         <span style={{ fontFamily: 'monospace', fontSize: 'clamp(18px, 5vw, 30px)', textAlign: 'center' }}>
-          A serial port terminal that's got your back.
+          An embedded developer's terminal that's got your back.
           <span className={styles.cursor}>&nbsp;</span>
         </span>
       </Grid>
@@ -280,8 +280,8 @@ export default function Home(): JSX.Element {
         <div className="container">
           <div className={styles.section}>
             <p className={styles.description}>
-              NinjaTerm is an open source and free electron (or web-based) application designed for viewing debug serial port data and sending commands when developing firmware for
-              an embedded device (e.g. microcontroller).
+              NinjaTerm is an open source and free electron (or web-based) application designed for viewing debug data and sending commands when developing firmware for an embedded
+              device (e.g. microcontroller). Connect via serial port, TCP socket, Bluetooth LE, or SEGGER RTT.
             </p>
             <p className={styles.description}>
               If you are looking for a serious terminal for continual use, the installable desktop versions are recommended. If you are looking for a quick way to view some serial

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="A serial port terminal that's got your back." />
+    <meta name="description" content="An embedded developer's terminal that's got your back." />
 
     <meta property="og:image" content="/github-readme-logo.png" />
     <meta property="og:image:width" content="1000" />


### PR DESCRIPTION
## Summary

- **Tagline**: "A serial port terminal that's got your back." → "An embedded developer's terminal that's got your back." NinjaTerm now supports four transports (serial, TCP socket, Bluetooth LE, SEGGER RTT), so the old wording undersold scope.
- **Homepage browser titles** no longer duplicate "NinjaTerm". Docusaurus auto-appends ` | NinjaTerm` from `siteConfig.title`, so the per-page `<Layout>` titles dropped the brand prefix (homepage tab is now `An embedded developer's terminal that's got your back | NinjaTerm`).
- **SEO + marketing copy**: `<Layout>` meta description, JSON-LD structured-data description, JSON-LD keywords (added `TCP socket`, `Bluetooth LE`, `SEGGER RTT`, `J-Link`), and the body intro paragraph no longer describe NinjaTerm as a serial port terminal.
- Updated everywhere the old wording appeared in non-`web/` files: homepage hero, browser titles, Docusaurus site tagline, manual intro + body, README, root `index.html` meta description.
- `web/` is left untouched per CLAUDE.md (maintenance mode).

## Test plan

- [x] `npx tsc` (root and `docs/`) — clean
- [ ] Manual: `cd docs && npm run start`, confirm browser tab reads `An embedded developer's terminal that's got your back | NinjaTerm`, hero text under logo and SEO meta description show the new tagline, no stale "serial port terminal" copy on the page.