### PR TITLE
Lower plain-ASCII perf-test floor 0.1 -> 0.07 MB/s

### DIFF
--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.perf.spec.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.perf.spec.ts
@@ -73,7 +73,10 @@ describe('SingleTerminal parsing throughput', () => {
     const mbPerSec = measure('plain-ASCII', payload, 4);
     // Loose floor — the printed number is the metric, this just guards
     // against catastrophic regressions (e.g. an O(n^2) loop creeping back in).
-    expect(mbPerSec).toBeGreaterThan(0.1);
+    // 0.07 not 0.1: a slow GitHub-hosted windows-latest runner clocked 0.0997
+    // MB/s — within noise of a healthy ~0.15 MB/s baseline but enough to flake
+    // a 0.1 floor.
+    expect(mbPerSec).toBeGreaterThan(0.07);
   }, 30_000);
 
   test('large single chunk (stresses Array.shift O(n^2))', () => {


### PR DESCRIPTION
## Summary

The `SingleTerminal parsing throughput > plain-ASCII chunks` perf test flaked on PR #393's CI, where the windows-latest runner clocked 0.09970568830612161 MB/s against a `> 0.1` floor. PR #393 was docs/copy only — no production code changed — so the failure was purely a flaky test.

The comment at the assertion already calls the floor "loose" and explains it's only meant to guard against catastrophic regressions (e.g. an O(n^2) loop creeping back in). 0.1 isn't loose if a healthy runner clocks 0.0997. Dropping to 0.07 keeps the regression guard (the prior O(n^2) bug clocked ~0.01 MB/s, well under) while leaving headroom for noise on slow hosted runners.

Local Windows run on this branch: `0.129 MB/s` — comfortably above 0.07.

## Test plan

- [x] `npx vitest run src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.perf.spec.ts` — all 4 perf tests pass locally
- [ ] Watch CI on this PR pass green across windows / macOS / ubuntu