### PR TITLE
Add find-in-scrollback (Ctrl+F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Also discoverable via a **Find** button in the terminal toolbar (next to **Filter**). Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
+- **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Also discoverable via a magnifying-glass icon in each pane's top-right (next to the copy-all button) — per-pane so in separate TX/RX mode each terminal has its own button and its own independent Find session. Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
+
 ### Changed
 
 - Homepage and `/app` redirect-page browser titles no longer say "NinjaTerm" twice. Docusaurus auto-appends ` | NinjaTerm` from `siteConfig.title`, so the per-page `Layout` titles now omit the brand prefix (homepage tab is now `An embedded developer's terminal that's got your back | NinjaTerm`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **TX Settings: opt out of Ctrl+F → Find.** New `Use Ctrl+F to open Find in scrollback` checkbox (default on). When off, Ctrl+F falls through to the Ctrl+A–Z handler so the ACK control byte (0x06) reaches the device — preserves the historic terminal behavior some embedded targets rely on. The per-pane Find magnifier buttons keep working either way. AppData migrated v16 → v17.
 - **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Also discoverable via a magnifying-glass icon in each pane's top-right (next to the copy-all button) — per-pane so in separate TX/RX mode each terminal has its own button and its own independent Find session. Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
+- **Find in scrollback (Ctrl+F).** Floating bar over the terminal pane with case-toggle, match counter, and prev/next nav (Enter / Shift+Enter, Esc closes). Also discoverable via a **Find** button in the terminal toolbar (next to **Filter**). Matches are highlighted in-place via two new CSS classes; current match is auto-scrolled into view, overriding scroll-lock while find is open. `SingleTerminalView`'s selection-restore logic is skipped while the Find input has focus so incoming RX traffic can't yank the caret out via `setBaseAndExtent`; FindBar clicks are also excluded from the mouseup selection-cache path. Implemented in `SingleTerminal.findMatches`, `FindBar.tsx`, and `TerminalRow.getSpans`.
 
 ### Changed
 

--- a/src/renderer/src/model/App.tsx
+++ b/src/renderer/src/model/App.tsx
@@ -885,8 +885,11 @@ export class App {
    * the current view mode and focus state. Falls back to a sensible default
    * when nothing is focused (the combined pane in single mode, the RX pane
    * in separate mode — that's where the bulk of searchable data lives).
+   *
+   * Public so the toolbar Find button in `TerminalsView` can share the same
+   * targeting logic as the Ctrl+F keyboard shortcut.
    */
-  private openFindOnPreferredTerminal() {
+  openFindOnPreferredTerminal() {
     const isSeparate = this.settings.displaySettings.dataViewConfiguration === DataViewConfiguration.SEPARATE_TX_RX_TERMINALS;
     let target: SingleTerminal;
     if (this.terminals.txTerminal.isFocused && isSeparate) {

--- a/src/renderer/src/model/App.tsx
+++ b/src/renderer/src/model/App.tsx
@@ -9,6 +9,7 @@ import { Button } from '@mui/material';
 import { log, initLogging } from './Util/Log';
 import packageDotJson from '../../../../package.json' with { type: 'json' };
 import { Settings, SettingsCategories } from './Settings/Settings';
+import { DataViewConfiguration } from './Settings/DisplaySettings/DisplaySettings';
 import SnackbarController from './SnackbarController/SnackbarController';
 import Graphing from './Graphing/Graphing';
 import Logging from './Logging/Logging';
@@ -790,6 +791,13 @@ export class App {
       await this.toggleDevTools();
     }
     //============================================
+    // FIND-IN-SCROLLBACK SHORTCUT (Ctrl+F)
+    //============================================
+    else if (event.ctrlKey && !event.shiftKey && (event.key === 'f' || event.key === 'F') && this.shownMainPane === MainPanes.TERMINAL) {
+      event.preventDefault(); // suppress the browser's built-in find dialog
+      this.openFindOnPreferredTerminal();
+    }
+    //============================================
     // COPY KEYBOARD SHORTCUT
     //============================================
     else if (event.ctrlKey && event.shiftKey && event.key === 'C') {
@@ -872,6 +880,25 @@ export class App {
    * @param event The keyboard event.
    * @returns
    */
+  /**
+   * Opens the Find bar on whichever terminal is the most useful target given
+   * the current view mode and focus state. Falls back to a sensible default
+   * when nothing is focused (the combined pane in single mode, the RX pane
+   * in separate mode — that's where the bulk of searchable data lives).
+   */
+  private openFindOnPreferredTerminal() {
+    const isSeparate = this.settings.displaySettings.dataViewConfiguration === DataViewConfiguration.SEPARATE_TX_RX_TERMINALS;
+    let target: SingleTerminal;
+    if (this.terminals.txTerminal.isFocused && isSeparate) {
+      target = this.terminals.txTerminal;
+    } else if (this.terminals.txRxTerminal.isFocused && !isSeparate) {
+      target = this.terminals.txRxTerminal;
+    } else {
+      target = isSeparate ? this.terminals.rxTerminal : this.terminals.txRxTerminal;
+    }
+    target.openFind();
+  }
+
   private handleCopyToClipboard(event: React.KeyboardEvent) {
     // Prevents Ctrl-Shift-C from opening the browser's dev tools
     event.preventDefault();

--- a/src/renderer/src/model/App.tsx
+++ b/src/renderer/src/model/App.tsx
@@ -793,7 +793,10 @@ export class App {
     //============================================
     // FIND-IN-SCROLLBACK SHORTCUT (Ctrl+F)
     //============================================
-    else if (event.ctrlKey && !event.shiftKey && (event.key === 'f' || event.key === 'F') && this.shownMainPane === MainPanes.TERMINAL) {
+    // When `useCtrlFForFind` is disabled, this branch is skipped and the
+    // event falls through to `handleTerminalKeyDown` so Ctrl+F sends the
+    // ACK control byte (0x06) like a historic terminal would.
+    else if (event.ctrlKey && !event.shiftKey && (event.key === 'f' || event.key === 'F') && this.shownMainPane === MainPanes.TERMINAL && this.settings.txSettings.useCtrlFForFind) {
       event.preventDefault(); // suppress the browser's built-in find dialog
       this.openFindOnPreferredTerminal();
     }

--- a/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
@@ -3,7 +3,8 @@ import fs from 'fs';
 import { expect, test, describe, beforeEach } from 'vitest';
 
 import { AppDataManager } from './AppDataManager';
-import { AppData } from './DataClasses/AppData';
+import { AppData, LATEST_VERSION } from './DataClasses/AppData';
+import { migrateAppData } from './appDataMigrations';
 import { App } from '../App';
 
 beforeEach(() => {
@@ -129,6 +130,31 @@ describe('app data manager tests', () => {
     const profileManager = new AppDataManager(app);
     expect(profileManager.appData.profiles.length).toEqual(1);
     expect(profileManager.appData.profiles[0].name).toEqual('Default profile');
+  });
+
+  test('migration v16->v17 seeds useCtrlFForFind=true on currentAppConfig and every profile', () => {
+    // Hand-crafted minimal v16 input — full snapshot fixtures live alongside
+    // the existing upgrade-from-vN tests; this one targets just the new step.
+    const v16Input = {
+      version: 16,
+      profiles: [
+        { name: 'p1', rootConfig: { settings: { txSettings: {} } } },
+        { name: 'p2', rootConfig: { settings: { txSettings: { useCtrlCVForCopyPaste: false } } } },
+      ],
+      currentAppConfig: { settings: { txSettings: {} } },
+    };
+
+    const { appData, wasChanged, unknownVersion } = migrateAppData(v16Input);
+
+    expect(unknownVersion).toBe(false);
+    expect(wasChanged).toBe(true);
+    expect(appData.version).toBe(LATEST_VERSION);
+    expect(appData.currentAppConfig?.settings?.txSettings?.useCtrlFForFind).toBe(true);
+    for (const profile of appData.profiles ?? []) {
+      expect(profile.rootConfig?.settings?.txSettings?.useCtrlFForFind).toBe(true);
+    }
+    // Other v16 fields must be left untouched.
+    expect(appData.profiles?.[1].rootConfig?.settings?.txSettings?.useCtrlCVForCopyPaste).toBe(false);
   });
 
   test('pushRttRecentDevice persists across a reload of AppDataManager', () => {

--- a/src/renderer/src/model/AppDataManager/DataClasses/AppData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/AppData.ts
@@ -3,7 +3,7 @@ import { makeAutoObservable } from "mobx";
 import { Profile } from "./Profile";
 import { ProfileConfig } from "./ProfileConfig";
 
-export const LATEST_VERSION = 16;
+export const LATEST_VERSION = 17;
 
 export class AppData {
   // Version of the AppData class.

--- a/src/renderer/src/model/AppDataManager/DataClasses/TxSettingsData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/TxSettingsData.ts
@@ -33,4 +33,12 @@ export class TxSettingsData {
    * If false, Ctrl+C/V always send control codes (0x03/0x16); use Ctrl+Shift+C/V for copy/paste.
    */
   useCtrlCVForCopyPaste = true;
+
+  /**
+   * If true (default), Ctrl+F opens the in-pane Find bar. If false, Ctrl+F
+   * falls through to the Ctrl+A–Z send path so the ACK control byte (0x06)
+   * is sent to the connected device, matching historic terminal behavior.
+   * The on-screen Find magnifier buttons work regardless of this setting.
+   */
+  useCtrlFForFind = true;
 }

--- a/src/renderer/src/model/AppDataManager/appDataMigrations.ts
+++ b/src/renderer/src/model/AppDataManager/appDataMigrations.ts
@@ -99,6 +99,8 @@ type MigrationTxSettings = {
   version?: number;
   // v12->v13
   useCtrlCVForCopyPaste?: boolean;
+  // v16->v17
+  useCtrlFForFind?: boolean;
 };
 
 type MigrationGraphingSettings = {
@@ -441,6 +443,18 @@ function migrateV15toV16(appData: MigrationAppData): void {
   appData.version = 16;
 }
 
+function migrateV16toV17(appData: MigrationAppData): void {
+  // Default the new Ctrl+F → Find toggle to true so existing users get the
+  // Find shortcut. Users who want raw Ctrl+F passthrough (sends 0x06 / ACK)
+  // can opt out in TX Settings.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.txSettings = rootConfig.settings.txSettings ?? {};
+    rootConfig.settings.txSettings.useCtrlFForFind = true;
+  });
+  appData.version = 17;
+}
+
 /**
  * Ordered table of migrations. Each entry knows the version it consumes; the
  * loop in `migrateAppData` runs them in order while the data's version is
@@ -463,6 +477,7 @@ const MIGRATIONS: ReadonlyArray<{ from: number; apply: (appData: MigrationAppDat
   { from: 13, apply: migrateV13toV14 },
   { from: 14, apply: migrateV14toV15 },
   { from: 15, apply: migrateV15toV16 },
+  { from: 16, apply: migrateV16toV17 },
 ];
 
 // --------------------------------------------------------------------------

--- a/src/renderer/src/model/Settings/TxSettings/TxSettings.ts
+++ b/src/renderer/src/model/Settings/TxSettings/TxSettings.ts
@@ -56,6 +56,14 @@ export default class TxSettings {
    */
   useCtrlCVForCopyPaste = true;
 
+  /**
+   * If true (default), Ctrl+F opens the in-pane Find bar. If false, Ctrl+F
+   * passes through to the Ctrl+A–Z handler so the ACK control byte (0x06)
+   * is sent to the connected device. The on-screen Find magnifier buttons
+   * work regardless of this setting.
+   */
+  useCtrlFForFind = true;
+
   constructor(profileManager: AppDataManager) {
     this.profileManager = profileManager;
     this._loadConfig();
@@ -74,6 +82,7 @@ export default class TxSettings {
     this.send0x01Thru0x1AWhenCtrlAThruZPressed = configToLoad.send0x01Thru0x1AWhenCtrlAThruZPressed;
     this.sendEscCharWhenAltKeyPressed = configToLoad.sendEscCharWhenAltKeyPressed;
     this.useCtrlCVForCopyPaste = configToLoad.useCtrlCVForCopyPaste;
+    this.useCtrlFForFind = configToLoad.useCtrlFForFind;
   };
 
   _saveConfig = () => {
@@ -85,6 +94,7 @@ export default class TxSettings {
     config.send0x01Thru0x1AWhenCtrlAThruZPressed = this.send0x01Thru0x1AWhenCtrlAThruZPressed;
     config.sendEscCharWhenAltKeyPressed = this.sendEscCharWhenAltKeyPressed;
     config.useCtrlCVForCopyPaste = this.useCtrlCVForCopyPaste;
+    config.useCtrlFForFind = this.useCtrlFForFind;
 
     this.profileManager.saveAppData();
   };
@@ -116,6 +126,11 @@ export default class TxSettings {
 
   setUseCtrlCVForCopyPaste = (value: boolean) => {
     this.useCtrlCVForCopyPaste = value;
+    this._saveConfig();
+  }
+
+  setUseCtrlFForFind = (value: boolean) => {
+    this.useCtrlFForFind = value;
     this._saveConfig();
   }
 }

--- a/src/renderer/src/model/Terminals/SingleTerminal/Find.spec.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/Find.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, describe, beforeEach } from 'vitest';
+
+import { stringToUint8Array } from 'src/model/Util/Util';
+import { DataDirection, SingleTerminal } from './SingleTerminal';
+import RxSettings from 'src/model/Settings/RxSettings/RxSettings';
+import DisplaySettings from 'src/model/Settings/DisplaySettings/DisplaySettings';
+import { AppDataManager } from 'src/model/AppDataManager/AppDataManager';
+import { App } from 'src/model/App';
+import SnackbarController from 'src/model/SnackbarController/SnackbarController';
+
+describe('find-in-scrollback', () => {
+  let terminal: SingleTerminal;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    const app = new App();
+    const profileManager = new AppDataManager(app);
+    const rxSettings = new RxSettings(profileManager);
+    const displaySettings = new DisplaySettings(profileManager);
+    const snackbar = new SnackbarController();
+    terminal = new SingleTerminal('test-find', true, rxSettings, displaySettings, snackbar, null);
+    terminal.setTerminalViewHeightPx(100);
+  });
+
+  test('returns no matches when find is closed', () => {
+    terminal.parseData(stringToUint8Array('hello world\n'), DataDirection.RX);
+    terminal.setFindQuery('hello');
+    expect(terminal.findMatches).toEqual([]);
+  });
+
+  test('returns no matches for empty query', () => {
+    terminal.parseData(stringToUint8Array('hello world\n'), DataDirection.RX);
+    terminal.openFind();
+    expect(terminal.findMatches).toEqual([]);
+  });
+
+  test('finds a single match', () => {
+    terminal.parseData(stringToUint8Array('hello world\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('world');
+    expect(terminal.findMatches.length).toBe(1);
+    expect(terminal.findMatches[0].rowIndex).toBe(0);
+    expect(terminal.findMatches[0].colStart).toBe(6);
+    expect(terminal.findMatches[0].colEnd).toBe(11);
+  });
+
+  test('finds multiple matches across rows', () => {
+    terminal.parseData(stringToUint8Array('foo bar\nfoo baz\nbar baz\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('foo');
+    const matches = terminal.findMatches;
+    expect(matches.length).toBe(2);
+    expect(matches[0].rowIndex).toBe(0);
+    expect(matches[1].rowIndex).toBe(1);
+  });
+
+  test('finds multiple matches within the same row', () => {
+    terminal.parseData(stringToUint8Array('abc abc abc\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('abc');
+    expect(terminal.findMatches.length).toBe(3);
+    expect(terminal.findMatches.map((m) => m.colStart)).toEqual([0, 4, 8]);
+  });
+
+  test('case-insensitive matching by default', () => {
+    terminal.parseData(stringToUint8Array('Hello HELLO hello\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('hello');
+    expect(terminal.findMatches.length).toBe(3);
+  });
+
+  test('case-sensitive matching when enabled', () => {
+    terminal.parseData(stringToUint8Array('Hello HELLO hello\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindCaseSensitive(true);
+    terminal.setFindQuery('hello');
+    expect(terminal.findMatches.length).toBe(1);
+    expect(terminal.findMatches[0].colStart).toBe(12);
+  });
+
+  test('nextMatch advances and wraps', () => {
+    terminal.parseData(stringToUint8Array('one\ntwo\nthree\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('o'); // matches: row 0 col 0, row 1 col 2
+    expect(terminal.findMatches.length).toBeGreaterThanOrEqual(2);
+    expect(terminal.currentMatchIndex).toBe(0);
+    terminal.nextMatch();
+    expect(terminal.currentMatchIndex).toBe(1);
+    // Wrap back to 0 after walking to the end.
+    const total = terminal.findMatches.length;
+    for (let i = 0; i < total - 1; i += 1) {
+      terminal.nextMatch();
+    }
+    expect(terminal.currentMatchIndex).toBe(0);
+  });
+
+  test('prevMatch wraps from start to end', () => {
+    terminal.parseData(stringToUint8Array('one two three\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('e');
+    const total = terminal.findMatches.length;
+    expect(total).toBeGreaterThan(1);
+    expect(terminal.currentMatchIndex).toBe(0);
+    terminal.prevMatch();
+    expect(terminal.currentMatchIndex).toBe(total - 1);
+  });
+
+  test('nextMatch / prevMatch are no-ops with zero matches', () => {
+    terminal.parseData(stringToUint8Array('hello\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('zzz');
+    expect(terminal.findMatches.length).toBe(0);
+    terminal.nextMatch();
+    expect(terminal.currentMatchIndex).toBe(0);
+    terminal.prevMatch();
+    expect(terminal.currentMatchIndex).toBe(0);
+  });
+
+  test('currentMatch returns null when no matches', () => {
+    terminal.parseData(stringToUint8Array('hello\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('zzz');
+    expect(terminal.currentMatch).toBeNull();
+  });
+
+  test('currentMatch returns the indexed match', () => {
+    terminal.parseData(stringToUint8Array('abc abc abc\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('abc');
+    expect(terminal.currentMatch?.colStart).toBe(0);
+    terminal.nextMatch();
+    expect(terminal.currentMatch?.colStart).toBe(4);
+    terminal.nextMatch();
+    expect(terminal.currentMatch?.colStart).toBe(8);
+  });
+
+  test('changing query resets currentMatchIndex to 0', () => {
+    terminal.parseData(stringToUint8Array('foo foo foo\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('foo');
+    terminal.nextMatch();
+    terminal.nextMatch();
+    expect(terminal.currentMatchIndex).toBe(2);
+    terminal.setFindQuery('foo'); // setting same query still resets — that's the contract
+    expect(terminal.currentMatchIndex).toBe(0);
+  });
+
+  test('closeFind clears the query', () => {
+    terminal.parseData(stringToUint8Array('hello\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('hello');
+    expect(terminal.findMatches.length).toBe(1);
+    terminal.closeFind();
+    expect(terminal.isFindOpen).toBe(false);
+    expect(terminal.findQuery).toBe('');
+    expect(terminal.findMatches).toEqual([]);
+  });
+
+  test('findMatchesByRow groups matches by row index', () => {
+    terminal.parseData(stringToUint8Array('foo\nbar foo\nbaz\n'), DataDirection.RX);
+    terminal.openFind();
+    terminal.setFindQuery('foo');
+    const byRow = terminal.findMatchesByRow;
+    expect(byRow.get(0)?.length).toBe(1);
+    expect(byRow.get(1)?.length).toBe(1);
+    expect(byRow.has(2)).toBe(false);
+  });
+
+  test('find searches within filtered rows only', () => {
+    terminal.parseData(stringToUint8Array('apple\nbanana\napricot\n'), DataDirection.RX);
+    terminal.setFilterText('ap'); // filters to apple, apricot (cursor row also included)
+    terminal.openFind();
+    terminal.setFindQuery('a');
+    // All matches should fall within filteredTerminalRows; rowIndex must be a
+    // valid index into filteredTerminalRows.
+    for (const m of terminal.findMatches) {
+      expect(m.rowIndex).toBeGreaterThanOrEqual(0);
+      expect(m.rowIndex).toBeLessThan(terminal.filteredTerminalRows.length);
+    }
+    // The banana row is filtered out, so no match can point to it.
+    const bananaRowIdx = terminal.filteredTerminalRows.findIndex((r) => r.text.startsWith('banana'));
+    expect(bananaRowIdx).toBe(-1);
+  });
+});

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
@@ -37,6 +37,17 @@ export enum DataDirection {
 }
 
 /**
+ * Represents a single match for the Find feature. Row index is into
+ * `filteredTerminalRows`, columns are character offsets into that row's
+ * `terminalChars` array. `colEnd` is exclusive.
+ */
+export interface FindMatch {
+  rowIndex: number;
+  colStart: number;
+  colEnd: number;
+}
+
+/**
  * Represents a single terminal-style user interface.
  */
 export class SingleTerminal {
@@ -104,6 +115,22 @@ export class SingleTerminal {
    */
   filterText: string = '';
 
+  //======================================================================
+  // FIND-IN-SCROLLBACK STATE
+  //======================================================================
+
+  /** True when the Find bar is visible on top of this terminal. */
+  isFindOpen: boolean = false;
+
+  /** Active find query. Empty string disables matching. */
+  findQuery: string = '';
+
+  /** Whether the find query is matched case-sensitively. */
+  findCaseSensitive: boolean = false;
+
+  /** Index into `findMatches` of the "current" match (the one auto-scrolled to). */
+  currentMatchIndex: number = 0;
+
   /**
    * The array of terminal rows which should be included in the filtered view
    * due to the filter text. This is a subset of the terminalRows array.
@@ -121,6 +148,54 @@ export class SingleTerminal {
       // Otherwise, check if the row text contains the filter text
       return row.text.includes(this.filterText);
     });
+  }
+
+  /**
+   * All matches of the active find query within `filteredTerminalRows`, in
+   * top-to-bottom, left-to-right order. Empty when find is closed, the
+   * query is empty, or there are no hits. Computed property — recomputed
+   * automatically when query, case-sensitivity, or rows change.
+   */
+  get findMatches(): FindMatch[] {
+    if (!this.isFindOpen || this.findQuery === '') {
+      return [];
+    }
+    const query = this.findCaseSensitive ? this.findQuery : this.findQuery.toLowerCase();
+    if (query.length === 0) {
+      return [];
+    }
+    const matches: FindMatch[] = [];
+    const rows = this.filteredTerminalRows;
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+      const rowText = rows[rowIndex].text;
+      const haystack = this.findCaseSensitive ? rowText : rowText.toLowerCase();
+      let from = 0;
+      let idx = haystack.indexOf(query, from);
+      while (idx !== -1) {
+        matches.push({ rowIndex, colStart: idx, colEnd: idx + query.length });
+        from = idx + query.length;
+        idx = haystack.indexOf(query, from);
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * Matches grouped by their row index for O(1) lookup during row rendering.
+   * Saves the FixedSizeList row renderer from doing a linear scan of
+   * `findMatches` for every visible row on every render.
+   */
+  get findMatchesByRow(): Map<number, FindMatch[]> {
+    const map = new Map<number, FindMatch[]>();
+    for (const match of this.findMatches) {
+      const list = map.get(match.rowIndex);
+      if (list) {
+        list.push(match);
+      } else {
+        map.set(match.rowIndex, [match]);
+      }
+    }
+    return map;
   }
 
   // True if this RX data parser is just processing text as plain text, i.e.
@@ -284,6 +359,9 @@ export class SingleTerminal {
 
     makeAutoObservable(this, {
       filteredTerminalRows: computed,
+      findMatches: computed,
+      findMatchesByRow: computed,
+      currentMatch: computed,
       terminalRows: observable.shallow, // Only observe array changes, not individual row changes
       lastKnownSelectionInfo: false, // Not MobX-tracked; updated during renders, not via actions
     });
@@ -1631,6 +1709,65 @@ export class SingleTerminal {
    * rows containing the filter text will be displayed.
    * @param filterText
    */
+  //======================================================================
+  // FIND-IN-SCROLLBACK ACTIONS
+  //======================================================================
+
+  openFind() {
+    this.isFindOpen = true;
+    // Reset the current-match pointer so navigation starts from the top of
+    // the new search. The first nextMatch() / scroll effect snaps to match 0.
+    this.currentMatchIndex = 0;
+  }
+
+  closeFind() {
+    this.isFindOpen = false;
+    this.findQuery = '';
+    this.currentMatchIndex = 0;
+  }
+
+  setFindQuery(query: string) {
+    this.findQuery = query;
+    // Any change to the query invalidates the previous match cursor — reset
+    // to match 0 so the user lands on the first hit of the new query.
+    this.currentMatchIndex = 0;
+  }
+
+  setFindCaseSensitive(value: boolean) {
+    this.findCaseSensitive = value;
+    this.currentMatchIndex = 0;
+  }
+
+  /** Advance to the next match, wrapping to the start at the end. No-op if there are no matches. */
+  nextMatch() {
+    const total = this.findMatches.length;
+    if (total === 0) {
+      this.currentMatchIndex = 0;
+      return;
+    }
+    this.currentMatchIndex = (this.currentMatchIndex + 1) % total;
+  }
+
+  /** Go to the previous match, wrapping to the end at the start. No-op if there are no matches. */
+  prevMatch() {
+    const total = this.findMatches.length;
+    if (total === 0) {
+      this.currentMatchIndex = 0;
+      return;
+    }
+    this.currentMatchIndex = (this.currentMatchIndex - 1 + total) % total;
+  }
+
+  /** The currently-focused match, or null if there are no matches. */
+  get currentMatch(): FindMatch | null {
+    const matches = this.findMatches;
+    if (matches.length === 0) {
+      return null;
+    }
+    const idx = Math.min(this.currentMatchIndex, matches.length - 1);
+    return matches[idx];
+  }
+
   setFilterText(filterText: string) {
     this.filterText = filterText;
 

--- a/src/renderer/src/view/Settings/TxSettings/TxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/TxSettings/TxSettingsView.tsx
@@ -175,6 +175,28 @@ function TxSettingsView(props: Props) {
             sx={{ marginBottom: '10px' }}
           />
         </Tooltip>
+        {/* =============================================================================== */}
+        {/* CTRL+F → FIND */}
+        {/* =============================================================================== */}
+        <Tooltip
+          title="When enabled (default): Ctrl+F opens the Find bar over the focused terminal pane. When disabled: Ctrl+F passes through to the Ctrl+A-Z handler, sending the ACK control byte (0x06) to the connected device — useful if your target firmware listens for it. The on-screen Find magnifier buttons next to each terminal still open Find regardless of this setting."
+          placement="top"
+          followCursor
+          {...txSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+        >
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={txSettings.useCtrlFForFind}
+                onChange={(e) => {
+                  txSettings.setUseCtrlFForFind(e.target.checked);
+                }}
+              />
+            }
+            label="Use Ctrl+F to open Find in scrollback (when off, Ctrl+F sends 0x06 / ACK)"
+            sx={{ marginBottom: '10px' }}
+          />
+        </Tooltip>
       </BorderedSection>
     </div>
   );

--- a/src/renderer/src/view/Terminals/SingleTerminal/FindBar.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/FindBar.tsx
@@ -1,0 +1,198 @@
+import { IconButton, InputBase, Tooltip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { observer } from 'mobx-react-lite';
+import { useEffect, useRef } from 'react';
+
+import { SingleTerminal } from 'src/model/Terminals/SingleTerminal/SingleTerminal';
+
+interface Props {
+  terminal: SingleTerminal;
+}
+
+/**
+ * Floating Find bar that lives in the top-right of a terminal pane. Shown
+ * only when `terminal.isFindOpen` is true (toggled by Ctrl+F).
+ *
+ * Keyboard:
+ *   Esc            — close the bar (also clears the query)
+ *   Enter          — jump to next match
+ *   Shift+Enter    — jump to previous match
+ */
+export default observer((props: Props) => {
+  const { terminal } = props;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus + select the query when the bar opens, so re-opening Find while
+  // an old query is still present lets the user immediately retype.
+  useEffect(() => {
+    if (terminal.isFindOpen && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [terminal.isFindOpen]);
+
+  /**
+   * Closes Find and parks focus on something that still bubbles keydown into
+   * `App.handleKeyDown`. Otherwise the input unmounts, focus falls back to
+   * `document.body` (outside `#outer-border`), and the next Ctrl+F is
+   * swallowed until the user clicks somewhere inside the app.
+   *
+   * Prefer the terminal pane itself when it is focusable, so the user can
+   * keep typing serial data immediately after closing Find. Fall back to
+   * `#outer-border` for non-focusable panes (e.g. the RX pane in
+   * separate-TX/RX mode).
+   */
+  const closeAndRestoreFocus = () => {
+    const terminalEl = document.getElementById(terminal.id) as HTMLElement | null;
+    const outerBorder = document.getElementById('outer-border') as HTMLElement | null;
+    const focusTarget =
+      terminalEl && terminal.isFocusable ? terminalEl : outerBorder ?? terminalEl;
+    focusTarget?.focus();
+    terminal.closeFind();
+  };
+
+  if (!terminal.isFindOpen) {
+    return null;
+  }
+
+  const matches = terminal.findMatches;
+  const total = matches.length;
+  const currentNumber = total === 0 ? 0 : terminal.currentMatchIndex + 1;
+  const hasQuery = terminal.findQuery.length > 0;
+  const noMatchesForQuery = hasQuery && total === 0;
+
+  return (
+    <div
+      data-testid={`${terminal.id}-find-bar`}
+      style={{
+        position: 'absolute',
+        top: '6px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 2,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '4px 6px',
+        backgroundColor: 'rgba(40, 40, 40, 0.95)',
+        border: '1px solid rgba(255, 255, 255, 0.2)',
+        borderRadius: '4px',
+        fontFamily: 'Consolas, Menlo, monospace',
+        // Keep the bar narrow enough that it doesn't cover the copy/scroll
+        // buttons on the right of the pane.
+        maxWidth: 'min(420px, 80%)',
+      }}
+      onKeyDown={(e) => {
+        // Stop the global key handler (App.handleKeyDown) from interpreting
+        // these as terminal keystrokes / shortcuts while the user is typing
+        // in the Find query.
+        e.stopPropagation();
+        if (e.key === 'Escape') {
+          closeAndRestoreFocus();
+        } else if (e.key === 'Enter') {
+          if (e.shiftKey) {
+            terminal.prevMatch();
+          } else {
+            terminal.nextMatch();
+          }
+        }
+      }}
+    >
+      <InputBase
+        inputRef={inputRef}
+        value={terminal.findQuery}
+        onChange={(e) => terminal.setFindQuery(e.target.value)}
+        placeholder="Find"
+        inputProps={{
+          'data-testid': `${terminal.id}-find-input`,
+          'aria-label': 'Find in terminal',
+          style: {
+            padding: '2px 6px',
+            color: 'white',
+            fontSize: '13px',
+          },
+        }}
+        sx={{
+          backgroundColor: 'rgba(0, 0, 0, 0.35)',
+          borderRadius: '3px',
+          width: '180px',
+          border: noMatchesForQuery ? '1px solid #e57373' : '1px solid transparent',
+        }}
+      />
+
+      <span
+        data-testid={`${terminal.id}-find-count`}
+        style={{
+          color: noMatchesForQuery ? '#e57373' : 'rgba(255, 255, 255, 0.75)',
+          fontSize: '12px',
+          minWidth: '52px',
+          textAlign: 'center',
+        }}
+      >
+        {hasQuery ? `${currentNumber} / ${total}` : ''}
+      </span>
+
+      <Tooltip title="Match case" disableInteractive>
+        <IconButton
+          size="small"
+          onClick={() => terminal.setFindCaseSensitive(!terminal.findCaseSensitive)}
+          sx={{
+            color: terminal.findCaseSensitive ? '#ffb74d' : 'rgba(255, 255, 255, 0.6)',
+            padding: '2px 6px',
+            fontSize: '13px',
+            fontWeight: 600,
+            lineHeight: 1,
+            borderRadius: '3px',
+            // Outline the toggle when active so it reads as "on" even at a glance.
+            border: terminal.findCaseSensitive ? '1px solid #ffb74d' : '1px solid transparent',
+          }}
+          data-testid={`${terminal.id}-find-case-toggle`}
+        >
+          Aa
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip title="Previous match (Shift+Enter)" disableInteractive>
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => terminal.prevMatch()}
+            disabled={total === 0}
+            sx={{ color: 'rgba(255, 255, 255, 0.75)', padding: '2px' }}
+            data-testid={`${terminal.id}-find-prev`}
+          >
+            <ExpandLessIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Tooltip title="Next match (Enter)" disableInteractive>
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => terminal.nextMatch()}
+            disabled={total === 0}
+            sx={{ color: 'rgba(255, 255, 255, 0.75)', padding: '2px' }}
+            data-testid={`${terminal.id}-find-next`}
+          >
+            <ExpandMoreIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Tooltip title="Close (Esc)" disableInteractive>
+        <IconButton
+          size="small"
+          onClick={() => closeAndRestoreFocus()}
+          sx={{ color: 'rgba(255, 255, 255, 0.75)', padding: '2px' }}
+          data-testid={`${terminal.id}-find-close`}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </div>
+  );
+});

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
@@ -160,3 +160,19 @@
 .b47.b, .b107 {
   background-color: var(--vga-bright-white);
 }
+
+/* FIND-IN-SCROLLBACK HIGHLIGHTS */
+/*================================================================*/
+/* Applied to every char in a non-current find match. */
+.findMatch {
+  background-color: rgba(255, 213, 79, 0.45); /* soft amber */
+  color: #111;
+}
+
+/* Applied to every char in the currently-focused find match. The Find bar
+   auto-scrolls to keep this in view; the stronger contrast makes it easy
+   to spot on a noisy screen. */
+.findMatchCurrent {
+  background-color: rgb(255, 152, 0); /* saturated amber */
+  color: #111;
+}

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
@@ -12,6 +12,7 @@ import styles from './SingleTerminalView.module.css';
 import './SingleTerminalView.css';
 import { SelectionController } from 'src/model/SelectionController/SelectionController';
 import DisplaySettings from 'src/model/Settings/DisplaySettings/DisplaySettings';
+import FindBar from './FindBar';
 
 interface Props {
   terminal: SingleTerminal;
@@ -36,6 +37,25 @@ export default observer((props: Props) => {
     const terminalRowToRender = data[index];
     const terminalRowCursorIsOn = terminal.terminalRows[terminal.cursorPosition[0]];
 
+    // Find-match ranges for this row (if any). Reads `findMatchesByRow` so
+    // MobX re-renders this row when the find state changes.
+    const rowFindMatches = terminal.findMatchesByRow.get(index);
+    const currentMatch = terminal.currentMatch;
+    const findRanges = rowFindMatches
+      ? rowFindMatches.map((m) => ({
+          colStart: m.colStart,
+          colEnd: m.colEnd,
+          isCurrent:
+            currentMatch !== null &&
+            currentMatch.rowIndex === m.rowIndex &&
+            currentMatch.colStart === m.colStart,
+        }))
+      : [];
+    // Stable string for the useMemo dependency array.
+    const findRangesKey = findRanges
+      .map((r) => `${r.colStart}-${r.colEnd}-${r.isCurrent ? 'c' : 'n'}`)
+      .join(',');
+
     // Use memoized span generation from TerminalRow.
     // `Row` is a nested function component (declared inside the parent's
     // body) so ESLint's rules-of-hooks heuristic flags this useMemo as
@@ -46,19 +66,21 @@ export default observer((props: Props) => {
       // Determine cursor class
       const cursorClass = terminal.isFocused ? styles.cursorFocused : styles.cursorUnfocused;
       const stylesWithCursor = { ...styles, cursorFocused: cursorClass };
-      
+
       return terminalRowToRender.getSpans(
         terminal.id,
         terminal.cursorPosition,
         terminalRowCursorIsOn,
-        stylesWithCursor
+        stylesWithCursor,
+        findRanges,
       );
     }, [
       terminalRowToRender.terminalCharsHash,
       terminal.cursorPosition[0],
       terminal.cursorPosition[1],
       terminal.isFocused,
-      terminalRowCursorIsOn?.uniqueRowId
+      terminalRowCursorIsOn?.uniqueRowId,
+      findRangesKey,
     ]);
 
     // Make a ID that is unique in the entire DOM tree. This means that we have to append the terminal
@@ -81,8 +103,25 @@ export default observer((props: Props) => {
   // removed from the start (buffer is full).
   // This needs to be done because when we recreate the list it does not
   // remember it's scroll position
+  // Read find-state observables here at render time so the `observer` HOC
+  // subscribes to them. MobX only tracks reads that happen during render —
+  // reads inside `useLayoutEffect` bodies do NOT subscribe, so without these
+  // lines the parent wouldn't re-render when the user clicks Next/Prev
+  // (currentMatch changes in isolation), and the scroll effect below
+  // wouldn't fire.
+  const isFindOpen = terminal.isFindOpen;
+  const currentMatchRowIndex = terminal.currentMatch?.rowIndex ?? -1;
+  const currentMatchColStart = terminal.currentMatch?.colStart ?? -1;
+
   useLayoutEffect(() => {
     if (reactWindowRef.current === null) {
+      return;
+    }
+    // While Find is open and pointing at a real match, scroll to keep that
+    // match in view. This takes precedence over scroll-lock so the user sees
+    // the highlighted hit instead of the tail of the buffer.
+    if (isFindOpen && currentMatchRowIndex >= 0) {
+      reactWindowRef.current.scrollToItem(currentMatchRowIndex, 'center');
       return;
     }
     if (terminal.scrollLock) {
@@ -94,11 +133,34 @@ export default observer((props: Props) => {
     }
   });
 
+  // Dedicated effect for find-driven scrolling. Fires when the user changes
+  // the query, hits next/prev, or opens Find — all of which the main effect
+  // above misses because nothing else in the parent's render reads these
+  // observables, so the parent wouldn't re-render on those events alone.
+  // Keying off rowIndex + colStart is enough to catch every navigation
+  // including consecutive matches on the same row.
+  useLayoutEffect(() => {
+    if (reactWindowRef.current === null) return;
+    if (!isFindOpen) return;
+    if (currentMatchRowIndex < 0) return;
+    reactWindowRef.current.scrollToItem(currentMatchRowIndex, 'center');
+  }, [isFindOpen, currentMatchRowIndex, currentMatchColStart]);
+
   // Capture the selection into the cache on mouseup (after the user finishes dragging).
   // At mouseup time both endpoints are guaranteed to be in the DOM, so getSelectionInfo
   // returns a valid result. We do NOT use selectionchange because Chrome fires it when
   // react-window removes DOM nodes, and the adjusted selection may be wrong.
   // Cache is cleared when the user clicks outside this terminal.
+  // Returns true if the given DOM node is inside this terminal's Find bar.
+  // The Find bar lives inside the outer terminal wrapper but is logically not
+  // part of the scrollback, so clicks / focus inside it must not be treated
+  // as terminal text selections.
+  const isInFindBar = (node: Node | null): boolean => {
+    if (!node) return false;
+    const findBarEl = document.querySelector(`[data-testid="${terminal.id}-find-bar"]`);
+    return findBarEl !== null && findBarEl.contains(node);
+  };
+
   useEffect(() => {
     let isSelectingInThisTerminal = false;
 
@@ -108,7 +170,12 @@ export default observer((props: Props) => {
       // correct for on-screen rows). The cache is repopulated at mouseup.
       terminal.lastKnownSelectionInfo = null;
       const terminalEl = document.getElementById(terminal.id);
-      if (terminalEl && terminalEl.contains(e.target as Node)) {
+      // Clicks inside the Find bar must NOT count as a terminal text selection.
+      // Otherwise mouseup would cache a SelectionInfo derived from the Find bar
+      // DOM, and the layout-effect selection-restore would call setBaseAndExtent
+      // on every subsequent RX-driven re-render — which yanks focus out of the
+      // Find input.
+      if (terminalEl && terminalEl.contains(e.target as Node) && !isInFindBar(e.target as Node)) {
         isSelectingInThisTerminal = true;
       } else {
         isSelectingInThisTerminal = false;
@@ -196,6 +263,11 @@ export default observer((props: Props) => {
   // live DOM selection because after virtualization Chrome adjusts the live selection
   // to another connected node, which would overwrite the correct highlight.
   useLayoutEffect(() => {
+    // Skip entirely when the user is interacting with the Find bar — any call
+    // to `selection.setBaseAndExtent` here would move the document selection
+    // and pull focus out of the Find input.
+    if (isInFindBar(document.activeElement)) return;
+
     if (applyLastKnownSelection()) return;
 
     // No cached selection (mousedown cleared it) — fall back to the live DOM selection.
@@ -312,6 +384,10 @@ export default observer((props: Props) => {
         }}
       >
         {/* ======================================================= */}
+        {/* FIND BAR (only visible when terminal.isFindOpen) */}
+        {/* ======================================================= */}
+        <FindBar terminal={terminal} />
+        {/* ======================================================= */}
         {/* DIRECTION INDICATOR */}
         {/* ======================================================= */}
         <div
@@ -400,6 +476,9 @@ export default observer((props: Props) => {
               // so useLayoutEffect never runs. We re-apply the cached selection here
               // every time react-window renders a new set of rows (including on scroll)
               // so the browser selection is always corrected after virtualization.
+              // Same guard as the layout-effect: don't disturb the document
+              // selection while the Find input has focus.
+              if (isInFindBar(document.activeElement)) return;
               applyLastKnownSelection();
             }}
             overscanCount={5}

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useLayoutEffect, useEffect, forwardRef, useMemo } from '
 import LockIcon from '@mui/icons-material/Lock';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import SearchIcon from '@mui/icons-material/Search';
 import { FixedSizeList } from 'react-window';
 
 import { SingleTerminal } from 'src/model/Terminals/SingleTerminal/SingleTerminal';
@@ -394,7 +395,7 @@ export default observer((props: Props) => {
           style={{
             position: 'absolute',
             top: 0,
-            right: '60px',
+            right: '90px',
             padding: '0px 10px',
             backgroundColor: 'rgba(40, 40, 40, 0.5)',
             fontFamily: 'Consolas, Menlo, monospace',
@@ -402,6 +403,34 @@ export default observer((props: Props) => {
         >
           {directionLabel}
         </div>
+        {/* ======================================================= */}
+        {/* FIND BUTTON (per-pane, opens Find on THIS terminal) */}
+        {/* ======================================================= */}
+        <Tooltip
+          {...displaySettings.getBasicTooltipConfig()}
+          title={`Find text in this ${directionLabel} terminal's scrollback (Ctrl+F).`}>
+        <IconButton
+          onClick={() => {
+            terminal.openFind();
+          }}
+          sx={{
+            position: 'absolute',
+            top: '0px',
+            right: '60px',
+            padding: '5px',
+            color: 'rgba(255, 255, 255, 0.7)',
+            zIndex: 1,
+          }}
+          data-testid={testId + '-find-button'}
+        >
+          <SearchIcon
+            sx={{
+              width: '20px',
+              height: '20px',
+            }}
+          />
+        </IconButton>
+        </Tooltip>
         {/* ======================================================= */}
         {/* CLIPBOARD COPY BUTTON */}
         {/* ======================================================= */}

--- a/src/renderer/src/view/Terminals/SingleTerminal/TerminalRow.tsx
+++ b/src/renderer/src/view/Terminals/SingleTerminal/TerminalRow.tsx
@@ -61,17 +61,47 @@ export default class TerminalRow {
   }
 
   /**
-   * Memoized span generation to avoid recreating spans on every render
+   * Memoized span generation to avoid recreating spans on every render.
+   *
+   * `findRanges` highlights matched columns from the Find feature. Each entry
+   * applies an extra class (`findMatch` for normal hits, `findMatchCurrent`
+   * for the active hit). Ranges within a single row are not expected to
+   * overlap. Passing the ranges through this method (rather than wrapping
+   * spans after generation) keeps the span-merging logic in one place and
+   * lets it correctly split runs of identical ANSI styling at match
+   * boundaries.
    */
-  getSpans(terminalId: string, cursorPosition: [number, number], terminalRowCursorIsOn: TerminalRow | null, styles: any): ReactElement[] {
+  getSpans(
+    terminalId: string,
+    cursorPosition: [number, number],
+    terminalRowCursorIsOn: TerminalRow | null,
+    styles: any,
+    findRanges: { colStart: number; colEnd: number; isCurrent: boolean }[] = [],
+  ): ReactElement[] {
     const currentHash = this.terminalCharsHash;
     const isCursorRow = this === terminalRowCursorIsOn;
-    const cacheKey = `${currentHash}:${isCursorRow}:${cursorPosition[1]}`;
-    
+    // Serialise findRanges into the cache key so the cache invalidates when
+    // the find state changes for this row. Cheap because per-row range count
+    // is tiny in practice.
+    const findKey = findRanges.length === 0
+      ? ''
+      : findRanges.map((r) => `${r.colStart}-${r.colEnd}-${r.isCurrent ? 'c' : 'n'}`).join(',');
+    const cacheKey = `${currentHash}:${isCursorRow}:${cursorPosition[1]}:${findKey}`;
+
     // Return cached spans if nothing changed
     if (this._spanCache && this._spanCache.terminalCharsHash === cacheKey) {
       return this._spanCache.spans;
     }
+
+    const findClassForCol = (colIdx: number): string => {
+      for (let i = 0; i < findRanges.length; i += 1) {
+        const r = findRanges[i];
+        if (colIdx >= r.colStart && colIdx < r.colEnd) {
+          return r.isCurrent ? ' findMatchCurrent' : ' findMatch';
+        }
+      }
+      return '';
+    };
 
     // Generate new spans
     const spans: ReactElement[] = [];
@@ -81,11 +111,15 @@ export default class TerminalRow {
     for (let colIdx = 0; colIdx < this.terminalChars.length; colIdx += 1) {
       const terminalChar = this.terminalChars[colIdx];
       let thisCharsClassName = terminalChar.className;
-      
+
       // Check if this is the cursor position
       if (isCursorRow && colIdx === cursorPosition[1]) {
         thisCharsClassName += ' ' + styles.cursorFocused;
       }
+
+      // Apply find-match highlight class (concatenated so it stacks with
+      // ANSI color classes — see SingleTerminalView.css for the rules).
+      thisCharsClassName += findClassForCol(colIdx);
 
       if (colIdx === 0) {
         prevClassName = thisCharsClassName;

--- a/src/renderer/src/view/Terminals/TerminalsView.tsx
+++ b/src/renderer/src/view/Terminals/TerminalsView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import CancelIcon from '@mui/icons-material/Cancel';
 import DeleteIcon from '@mui/icons-material/Delete';
+import SearchIcon from '@mui/icons-material/Search';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { OverridableStringUnion } from '@mui/types';
 import KofiButton from 'kofi-button';
@@ -146,6 +147,22 @@ export default observer((props: Props) => {
         >
           {isSmallScreen ? '' : 'Clear'}
         </Button>
+        {/* ==================================================================== */}
+        {/* FIND BUTTON (Ctrl+F) */}
+        {/* ==================================================================== */}
+        <Tooltip title="Find text in the terminal scrollback (Ctrl+F).">
+          <Button
+            variant="outlined"
+            startIcon={<SearchIcon />}
+            onClick={() => {
+              app.openFindOnPreferredTerminal();
+            }}
+            sx={responsiveButtonStyle}
+            data-testid="find-button"
+          >
+            {isSmallScreen ? '' : 'Find'}
+          </Button>
+        </Tooltip>
         {/* ======================================================= */}
         {/* FILTER TEXT INPUT */}
         {/* ======================================================= */}

--- a/src/renderer/src/view/Terminals/TerminalsView.tsx
+++ b/src/renderer/src/view/Terminals/TerminalsView.tsx
@@ -9,7 +9,6 @@ import {
 } from '@mui/material';
 import CancelIcon from '@mui/icons-material/Cancel';
 import DeleteIcon from '@mui/icons-material/Delete';
-import SearchIcon from '@mui/icons-material/Search';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { OverridableStringUnion } from '@mui/types';
 import KofiButton from 'kofi-button';
@@ -147,22 +146,6 @@ export default observer((props: Props) => {
         >
           {isSmallScreen ? '' : 'Clear'}
         </Button>
-        {/* ==================================================================== */}
-        {/* FIND BUTTON (Ctrl+F) */}
-        {/* ==================================================================== */}
-        <Tooltip title="Find text in the terminal scrollback (Ctrl+F).">
-          <Button
-            variant="outlined"
-            startIcon={<SearchIcon />}
-            onClick={() => {
-              app.openFindOnPreferredTerminal();
-            }}
-            sx={responsiveButtonStyle}
-            data-testid="find-button"
-          >
-            {isSmallScreen ? '' : 'Find'}
-          </Button>
-        </Tooltip>
         {/* ======================================================= */}
         {/* FILTER TEXT INPUT */}
         {/* ======================================================= */}


### PR DESCRIPTION
## Summary

- Adds a per-pane Find bar triggered by Ctrl+F. Case toggle, match count, prev/next nav (Enter / Shift+Enter, Esc closes). Matches highlighted in-place; current match auto-scrolls to centre, overriding scroll-lock while Find is open.
- Find runs against `filteredTerminalRows` so it composes with the existing row filter (filter narrows the haystack, Find searches within).
- 16 new Vitest tests in `Find.spec.ts` covering match computation, case sensitivity, wrap-around nav, currentMatch indexing, filter+find interaction.

## Non-obvious bits

- **Focus loss on RX traffic.** `SingleTerminalView`'s selection-restore (`setBaseAndExtent`) was yanking focus out of the Find input on every RX-driven re-render. Skipped when the active element is inside the Find bar; FindBar clicks are also excluded from the mouseup selection-cache path.
- **Next/Prev didn't scroll.** The parent observer didn't read `currentMatch` during render, so `mobx-react-lite` wasn't subscribed and the scroll layout-effect never re-fired on nav. Fixed by reading the find observables at render time and driving scroll from a dedicated effect keyed on `rowIndex` + `colStart`.
- **Ctrl+F dead after close.** Closing the bar unmounted the focused input; focus fell back to `document.body` (outside `#outer-border`), so the next Ctrl+F was swallowed. FindBar now restores focus to the terminal pane (or `#outer-border` for non-focusable panes) before calling `closeFind`.

## Test plan

- [ ] Open Find with Ctrl+F on the combined TX/RX pane (single-terminal mode) — bar appears centred at top, input focused.
- [ ] Type a query — matches highlighted amber, current match deeper amber, count updates live.
- [ ] Enter / Shift+Enter advance / retreat through matches with wrap-around; current match scrolls to centre.
- [ ] Toggle case sensitivity (`Aa`) — match set updates.
- [ ] Stream incoming RX data while Find input has focus — caret stays put, matches update as new rows arrive.
- [ ] Esc closes the bar; immediately press Ctrl+F again — bar reopens.
- [ ] Separate TX/RX mode: Ctrl+F opens on RX pane by default; opens on TX pane when TX is focused.
- [ ] Apply a row filter, then Find — search is scoped to the filtered subset.