### PR TITLE
Publish releases via draft to avoid mid-upload update 404s

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,10 +85,46 @@ jobs:
       env:
         CSC_IDENTITY_AUTO_DISCOVERY: false
 
-  release:
-    # Tag-push only. Builds signed artifacts on all three platforms and publishes
-    # them to a new GitHub Release via `electron-builder --publish always`.
+  create-draft-release:
+    # Tag-push only. Creates the DRAFT GitHub Release up-front so that:
+    # (a) the three platform `release` jobs below all upload into the same
+    #     draft instead of racing to create one (electron-builder matrix
+    #     builds can otherwise create duplicate releases), and
+    # (b) the release stays invisible to auto-updaters until `publish-release`
+    #     flips it public after every artifact is attached. Previously the
+    #     release went public the moment the first platform finished, so
+    #     clients that checked for updates mid-upload got 404s on latest.yml.
     needs: test-electron
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Create draft release for tag (idempotent)
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        PRERELEASE_FLAG=""
+        case "$VERSION" in
+          *-*) PRERELEASE_FLAG="--prerelease" ;;
+        esac
+        if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+          # Re-run of the workflow — release (draft or published) already exists.
+          echo "Release $GITHUB_REF_NAME already exists; not creating another."
+        else
+          gh release create "$GITHUB_REF_NAME" --draft $PRERELEASE_FLAG \
+            --title "$VERSION" \
+            --notes "Build in progress - artifacts are still being uploaded by CI."
+        fi
+
+  release:
+    # Tag-push only. Builds signed artifacts on all three platforms and uploads
+    # them to the DRAFT GitHub Release created by `create-draft-release`
+    # (electron-builder finds the existing draft by tag and uploads into it —
+    # `releaseType: "draft"` in package.json's build.publish config). The
+    # release is made public afterwards by `publish-release`.
+    needs: create-draft-release
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
 
@@ -149,10 +185,12 @@ jobs:
         # Publish to GitHub Releases
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  release-notes:
-    # Runs once, after all three platform builds in `release` have uploaded.
-    # Extracts the matching `## [X.Y.Z]` section from CHANGELOG.md and sets it
-    # as the GitHub Release body via `gh release edit`.
+  publish-release:
+    # Runs once, after all three platform builds in `release` have uploaded
+    # their installers AND update manifests (latest*.yml) to the draft release.
+    # Sets the release body from CHANGELOG.md, then flips the draft public.
+    # Publishing last means auto-updaters never see a half-uploaded release,
+    # and if any platform build fails the release stays an invisible draft.
     needs: release
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -178,8 +216,20 @@ jobs:
         ' CHANGELOG.md | sed '/^$/N;/^\n$/D' > release-notes.md
 
         if [ ! -s release-notes.md ]; then
+          # Non-fatal: a missing CHANGELOG section shouldn't block publishing
+          # the release itself (the next step still runs).
           echo "Could not extract CHANGELOG section for $VERSION; leaving release body untouched." >&2
           exit 0
         fi
 
         gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md
+
+    - name: Publish release (draft -> public)
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        case "$VERSION" in
+          *-*) gh release edit "$GITHUB_REF_NAME" --draft=false --prerelease ;;
+          *)   gh release edit "$GITHUB_REF_NAME" --draft=false --latest ;;
+        esac

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-15, ubuntu-latest, windows-latest]
+        # Windows pinned to windows-2022 (not windows-latest): the windows-latest
+        # image rolled in Visual Studio 18, which node-gyp 10.x can't detect
+        # (ERR_CHILD_PROCESS_STDIO_MAXBUFFER), breaking native-module builds
+        # during `npm ci`. windows-2022 keeps the VS 2022 toolchain that builds
+        # cleanly. Revisit once node-gyp is upgraded to a VS18-aware version.
+        os: [macos-15, ubuntu-latest, windows-2022]
 
     steps:
     - name: Checkout code
@@ -67,7 +72,7 @@ jobs:
     # signed build + publish on tag pushes.
     #===============================================================
     - name: Package Electron app (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       run: npx electron-builder --win --publish never
       env:
         CSC_IDENTITY_AUTO_DISCOVERY: false
@@ -130,7 +135,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15]
+        # Windows pinned to windows-2022 — see note in the test-electron matrix.
+        os: [ubuntu-latest, windows-2022, macos-15]
 
     steps:
     - name: Check out Git repository
@@ -160,7 +166,7 @@ jobs:
     # NOTE: More build config is in package.json under the "build" key.
     #===============================================================
     - name: Build/release Electron app (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       run: npx electron-builder --win --publish always
       env:
         # Windows code signing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- **Update checks no longer 404 mid-release.** CI now uploads installers to a draft GitHub Release (new `create-draft-release` job + `releaseType: "draft"`) and the `publish-release` job only makes it public once all platforms' artifacts, including `latest*.yml`, are attached.
+
 ## [5.13.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **Update checks no longer 404 mid-release.** CI now uploads installers to a draft GitHub Release (new `create-draft-release` job + `releaseType: "draft"`) and the `publish-release` job only makes it public once all platforms' artifacts, including `latest*.yml`, are attached.
+- **Windows CI builds fixed.** Pinned the Windows runner to `windows-2022`; the `windows-latest` image added Visual Studio 18, which `node-gyp` 10.x fails to detect during native-module builds in `npm ci`.
 
 ## [5.13.0] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -138,19 +138,25 @@ branch.
 (We use `--preview` rather than `--dry-run` because npm intercepts `--dry-run`
 as one of its own flags before it reaches the script.)
 
-From there CI takes over: it builds and signs all three platforms, creates the
-GitHub Release, uploads the installers / updater manifests, and extracts the
-`## [X.Y.Z]` section from CHANGELOG.md as the Release body. There's no manual
-"create draft release" step any more.
+From there CI takes over: it builds and signs all three platforms, uploads the
+installers / updater manifests to a **draft** GitHub Release, and only flips
+the release public once every artifact is attached (with the `## [X.Y.Z]`
+section from CHANGELOG.md as the Release body). The draft stage matters:
+auto-updaters can't see drafts, so existing installs never hit a 404 on
+`latest.yml` while uploads are still in flight — and if any platform build
+fails, the release stays an invisible draft rather than going out incomplete.
 
 **How CI works:**
 - On every `main` / `dev` push: `test-electron` runs unit tests, the Electron
   e2e suite (Ubuntu), and a packaging smoke-test on all three platforms with
   `--publish never`. No upload.
-- On a `v*` tag push: `test-electron` runs first, then the `release` job
-  rebuilds all three platforms with signing + `electron-builder --publish always`,
-  which creates the GitHub Release and attaches the artifacts. A follow-up
-  `release-notes` job fills the Release body from CHANGELOG via `gh release edit`.
+- On a `v*` tag push: `test-electron` runs first, then `create-draft-release`
+  creates the draft GitHub Release (one canonical release — avoids the
+  electron-builder matrix race that can create duplicates), then the `release`
+  job rebuilds all three platforms with signing + `electron-builder --publish
+  always` (uploading into the draft — `releaseType: "draft"` in package.json's
+  `build.publish`). A final `publish-release` job fills the Release body from
+  CHANGELOG and publishes the draft via `gh release edit --draft=false`.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
       "provider": "github",
       "owner": "gbmhunter",
       "repo": "NinjaTerm",
-      "releaseType": "release"
+      "releaseType": "draft"
     }
   },
   "type": "module"


### PR DESCRIPTION
## Problem

electron-builder's `releaseType: "release"` made the GitHub Release **public the instant the first platform job finished publishing** — minutes before `latest.yml` and the Windows installer were uploaded. Existing installs that ran an update check during that window got a 404 on `latest.yml` (observed live with v5.13.0).

## Fix — draft-first release flow

- **`package.json`**: `build.publish.releaseType` `release` → `draft`.
- **New `create-draft-release` job** (tag-push only, after `test-electron`): creates one canonical draft release up-front via `gh release create --draft` (idempotent on re-runs; `--prerelease` for `-rc.N` tags). Pre-creating it means the three matrix `release` jobs upload into the same draft instead of racing to create duplicates.
- **`release`** now `needs: create-draft-release` and uploads into the draft.
- **`release-notes` → `publish-release`**: sets the body from CHANGELOG (best-effort), then flips the draft public with `gh release edit --draft=false` (`--latest`, or `--prerelease` for rc tags).

Job chain: `test-electron → create-draft-release → release → publish-release`.

## Result

Auto-updaters can't see drafts, so clients only ever see a release once **every** installer and `latest*.yml` manifest is attached. Bonus: a failed platform build now leaves an invisible draft rather than a half-published release.

## Verification

- Workflow YAML parses; job `needs` graph confirmed as above.
- End-to-end behavior can only be fully exercised by a real `v*` tag push — worth watching the next release run (or cutting a cheap `-rc.1` prerelease to dry-run it).

README "Releasing" / "How CI works" sections and a CHANGELOG `Unreleased` entry updated to match.