### PR TITLE
Add DCH (Delete Character, ESC[P) escape sequence support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Backspace (0x08/DEL 0x7F) handling ([#401](https://github.com/gbmhunter/NinjaTerm/issues/401)).** New RX "Backspace" setting with three behaviors — display as glyph, move cursor left (strict ANSI), or destructive (move left + erase char, the new default). Handled in `SingleTerminal.parseData` via `_backspaceDeleteChar`; AppData migrated v19→v20.
 - **Fake port "typing with backspace corrections"** that streams shell-style typing with typo fixes (lone `\b` and the `\b \b` erase sequence), one byte at a time, for testing the new backspace setting.
 - **Fake port "silent (no data)"** that opens a connection but emits nothing — useful for testing local echo / backspace handling by typing, without RX traffic interfering.
+- **DCH (Delete Character) escape sequence ([#404](https://github.com/gbmhunter/NinjaTerm/issues/404)).** `ESC[P` / `ESC[nP` deletes characters at the cursor and shifts the rest of the line left, for proper forward-delete emulation. Handled in `SingleTerminal._parseCSISequence` via the new `_deleteChars`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Fake port "typing with backspace corrections"** that streams shell-style typing with typo fixes (lone `\b` and the `\b \b` erase sequence), one byte at a time, for testing the new backspace setting.
 - **Fake port "silent (no data)"** that opens a connection but emits nothing — useful for testing local echo / backspace handling by typing, without RX traffic interfering.
 - **DCH (Delete Character) escape sequence ([#404](https://github.com/gbmhunter/NinjaTerm/issues/404)).** `ESC[P` / `ESC[nP` deletes characters at the cursor and shifts the rest of the line left, for proper forward-delete emulation. Handled in `SingleTerminal._parseCSISequence` via the new `_deleteChars`.
+- **Manual now lists all supported ANSI escape codes** in a summary table (cursor moves, DCH, Erase in Display, and SGR codes) in the ANSI Escape Codes section.
 
 ### Fixed
 

--- a/docs/docs/manual.mdx
+++ b/docs/docs/manual.mdx
@@ -130,7 +130,18 @@ NinjaTerm defaults to RTT up/down channel 0 (the "Terminal" channel, what `SEGGE
 
 ## ANSI Escape Codes
 
-NinjaTerm supports a number of the most popular ASCII escape codes for manipulating the terminal. They are commonly used for coloring/styling text (e.g. making errors red), moving the cursor around and deleting data (e.g. clearing the screen, or re-writing an existing row). These features are very useful when making interactive prompts.
+NinjaTerm supports a number of the most popular ANSI escape codes for manipulating the terminal. They are commonly used for coloring/styling text (e.g. making errors red), moving the cursor around and deleting data (e.g. clearing the screen, or re-writing an existing row). These features are very useful when making interactive prompts.
+
+Parsing can be toggled with the ANSI escape code parsing setting in `Settings > RX Settings`. `n` is an optional numeric parameter that defaults to `1` (or `0` for Erase in Display). Sequences that are not in the table below are parsed but otherwise ignored.
+
+| Sequence | Name | Effect |
+| --- | --- | --- |
+| `ESC[nA` | Cursor Up (CUU) | Move the cursor up `n` rows (won't go above the first row or into scrollback). |
+| `ESC[nC` | Cursor Forward (CUF) | Move the cursor right `n` columns (capped at the terminal width). |
+| `ESC[nD` | Cursor Back (CUB) | Move the cursor left `n` columns (capped at column 0). |
+| `ESC[nP` | Delete Character (DCH) | Delete `n` characters at the cursor, shifting the rest of the line left. |
+| `ESC[nJ` | Erase in Display (ED) | Clear part of the screen — see below. |
+| `ESC[...m` | Select Graphic Rendition (SGR) | Set text color/style — see below. |
 
 ### Erase in Display (ESC[nJ)
 
@@ -143,6 +154,17 @@ The current rows in view are ignored when performing Erase in Display commands, 
 `ESC[2J` (clear entire screen) will insert enough empty, blank rows into the terminal such that the cursor would be at the top right of the view port with a "blank screen" if the user was not looking in the scrollback.
 
 `ESC[3J` (clear all data from terminal and scrollback buffer) will delete all data in the terminal and the scrollback buffer. This is the same as pressing the clear button in the terminal view.
+
+### Select Graphic Rendition (ESC[...m)
+
+Sets the text style for subsequent characters. Multiple codes can be combined, separated by `;` (e.g. `ESC[1;31m` for bold red). The supported codes are:
+
+- `0` — reset all styles (also the default when no code is given, i.e. `ESC[m`)
+- `1` — bold / increased intensity
+- `30`–`37` — foreground color, `90`–`97` — bright foreground color
+- `40`–`47` — background color, `100`–`107` — bright background color
+
+These can override the default background/TX/RX colors set in `Settings > Display`.
 
 ## Timestamps
 

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
@@ -914,6 +914,75 @@ describe('single terminal tests', () => {
       expect(singleTerminal.cursorPosition).toEqual([0, 2]);
     });
   });
+
+  //================================================================================
+  // DCH (Delete Character, ESC[P)
+  //================================================================================
+  describe('DCH delete character', () => {
+    test('ESC[P deletes the character under the cursor and shifts the rest left', () => {
+      // 'abcd', move cursor left 2 (onto 'c'), then ESC[P -> 'abd'.
+      const data = new Uint8Array([
+        0x61, 0x62, 0x63, 0x64, // 'abcd'
+        0x1b, 0x5b, 0x32, 0x44, // ESC[2D (cursor left 2)
+        0x1b, 0x5b, 0x50, // ESC[P (delete 1 char)
+      ]);
+      singleTerminal.parseData(data, DataDirection.RX);
+
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars.length).toBe(3);
+      expect(chars[0].char).toBe('a');
+      expect(chars[1].char).toBe('b');
+      expect(chars[2].char).toBe('d');
+      // Cursor stays put.
+      expect(singleTerminal.cursorPosition).toEqual([0, 2]);
+    });
+
+    test('ESC[nP deletes n characters', () => {
+      // 'abcde', move cursor left 3 (onto 'c'), then ESC[2P -> 'abe'.
+      const data = new Uint8Array([
+        0x61, 0x62, 0x63, 0x64, 0x65, // 'abcde'
+        0x1b, 0x5b, 0x33, 0x44, // ESC[3D
+        0x1b, 0x5b, 0x32, 0x50, // ESC[2P
+      ]);
+      singleTerminal.parseData(data, DataDirection.RX);
+
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars.length).toBe(3);
+      expect(chars[0].char).toBe('a');
+      expect(chars[1].char).toBe('b');
+      expect(chars[2].char).toBe('e');
+      expect(singleTerminal.cursorPosition).toEqual([0, 2]);
+    });
+
+    test('ESC[P at the end of the line is a no-op', () => {
+      // Nothing to the right of the cursor to delete.
+      const data = new Uint8Array([0x61, 0x62, 0x63, 0x1b, 0x5b, 0x50]); // 'abc' + ESC[P
+      singleTerminal.parseData(data, DataDirection.RX);
+
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars[0].char).toBe('a');
+      expect(chars[1].char).toBe('b');
+      expect(chars[2].char).toBe('c');
+      // Trailing cursor-holder space remains untouched.
+      expect(chars[3].forCursor).toBe(true);
+      expect(singleTerminal.cursorPosition).toEqual([0, 3]);
+    });
+
+    test('ESC[nP is clamped to the characters remaining on the line', () => {
+      // 'ab', move cursor to start, delete more chars than exist -> empty line.
+      const data = new Uint8Array([
+        0x61, 0x62, // 'ab'
+        0x1b, 0x5b, 0x32, 0x44, // ESC[2D (cursor to col 0)
+        0x1b, 0x5b, 0x39, 0x50, // ESC[9P
+      ]);
+      singleTerminal.parseData(data, DataDirection.RX);
+
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars.length).toBe(1);
+      expect(chars[0].forCursor).toBe(true);
+      expect(singleTerminal.cursorPosition).toEqual([0, 0]);
+    });
+  });
 });
 
 function printTerminalRows(terminalRows: TerminalRow[]) {

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
@@ -1110,6 +1110,59 @@ export class SingleTerminal {
           console.log(`Number ${numberCode} provided to SGR control sequence unsupported.`);
         }
       }
+    } else if (lastChar === 'P') {
+      //============================================================
+      // DCH Delete Character
+      //============================================================
+      // Syntax: ESC[nP — delete n characters at the cursor position, shifting
+      // the remainder of the line left. n defaults to 1 if not provided. This
+      // is the output-side control a device emits to forward-delete (distinct
+      // from ESC[3~, which is what the Delete *key* sends to the host).
+      let numberStr = ansiEscapeCode.slice(2, ansiEscapeCode.length - 1);
+      if (numberStr === '') {
+        numberStr = '1';
+      }
+      const numCharsToDelete = parseInt(numberStr, 10);
+      if (Number.isNaN(numCharsToDelete)) {
+        console.error(`Number string in Delete Character (DCH) CSI sequence could not be converted into integer. numberStr=${numberStr}.`);
+        return;
+      }
+      this._deleteChars(numCharsToDelete);
+    }
+  }
+
+  /**
+   * Deletes characters at the current cursor position, shifting the remainder
+   * of the line left (the DCH / ESC[nP operation). The cursor does not move.
+   * The trailing space that only holds the cursor is never deleted, so a
+   * forward-delete at the end of the line is a no-op.
+   *
+   * @param numChars The number of characters to delete.
+   */
+  _deleteChars(numChars: number) {
+    if (numChars <= 0) {
+      return;
+    }
+    const currRow = this.terminalRows[this.cursorPosition[0]];
+    const col = this.cursorPosition[1];
+    let numDeletable = currRow.terminalChars.length - col;
+    // Don't count the trailing cursor-holder space as a deletable character.
+    const lastIdx = currRow.terminalChars.length - 1;
+    if (numDeletable > 0 && currRow.terminalChars[lastIdx].forCursor) {
+      numDeletable -= 1;
+    }
+    const numToDelete = Math.min(numChars, numDeletable);
+    if (numToDelete <= 0) {
+      return;
+    }
+    currRow.terminalChars.splice(col, numToDelete);
+    // Make sure there is still a character under the cursor to hold it (needed
+    // when the deletion reached the end of the line).
+    if (col === currRow.terminalChars.length) {
+      const spaceTerminalChar = new TerminalChar();
+      spaceTerminalChar.char = ' ';
+      spaceTerminalChar.forCursor = true;
+      currRow.terminalChars.push(spaceTerminalChar);
     }
   }
 


### PR DESCRIPTION
Closes #404.

## Summary

Adds **DCH (Delete Character)** support — `ESC[P` / `ESC[nP` — to the terminal parser. This is the standard output-side control a device emits to forward-delete characters (distinct from `ESC[3~`, which is what the Delete *key* sends to the host).

## Behavior

- `ESC[P` deletes 1 character at the cursor; `ESC[nP` deletes `n`.
- Characters to the right of the cursor shift left; the cursor stays put.
- The trailing space that only holds the cursor is never deleted, so a forward-delete at the end of the line is a no-op.
- `n` is clamped to the number of characters remaining on the row.

## Changes

- `SingleTerminal.ts` — new `else if (lastChar === 'P')` branch in `_parseCSISequence` + `_deleteChars` helper
- `SingleTerminal.spec.ts` — 4 new tests (single delete, multi-char, end-of-line no-op, clamping)
- `CHANGELOG.md` — Unreleased entry

## Background

Follow-up to #401. The distinction between the input sequence (`ESC[3~`, Delete key → host) and the output control (`ESC[P`, DCH) is covered in #404.

## Verification

- `npm run test:unit` → SingleTerminal suite 49 passed
- `npx tsc` → clean
