### PR TITLE
Disable default Warning/Error highlight rules by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Fake port "typing with backspace corrections"** that streams shell-style typing with typo fixes (lone `\b` and the `\b \b` erase sequence), one byte at a time, for testing the new backspace setting.
 - **Fake port "silent (no data)"** that opens a connection but emits nothing — useful for testing local echo / backspace handling by typing, without RX traffic interfering.
 
+### Changed
+
+- **Default Warning/Error highlight rules now ship disabled.** The two starter rules are off out of the box (`makeDefaultHighlightRules`); existing users have them switched off via the v19→v20 AppData migration (custom rules are left untouched).
+
 ### Fixed
 
 - **CSI escape sequences ending in `~` no longer swallow the following byte.** The CSI parser now terminates on the full ECMA-48 final-byte range (0x40–0x7E) instead of just ASCII letters, so the VT sequences sent by the Delete/Home/End/PgUp/PgDn/Insert keys (`ESC[1~`…`ESC[6~`) are parsed cleanly rather than hanging the parser until the next keystroke.

--- a/local-storage-data/appData-v20-app-v5.14.0-default.json
+++ b/local-storage-data/appData-v20-app-v5.14.0-default.json
@@ -267,7 +267,7 @@
               {
                 "version": 1,
                 "name": "Warning",
-                "enabled": true,
+                "enabled": false,
                 "pattern": "warning",
                 "caseSensitive": false,
                 "backgroundColor": "#df8004",
@@ -277,7 +277,7 @@
               {
                 "version": 1,
                 "name": "Error",
-                "enabled": true,
+                "enabled": false,
                 "pattern": "error",
                 "caseSensitive": false,
                 "backgroundColor": "#b71c1c",
@@ -554,7 +554,7 @@
           {
             "version": 1,
             "name": "Warning",
-            "enabled": true,
+            "enabled": false,
             "pattern": "warning",
             "caseSensitive": false,
             "backgroundColor": "#df8004",
@@ -564,7 +564,7 @@
           {
             "version": 1,
             "name": "Error",
-            "enabled": true,
+            "enabled": false,
             "pattern": "error",
             "caseSensitive": false,
             "backgroundColor": "#b71c1c",

--- a/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
@@ -254,6 +254,56 @@ describe('app data manager tests', () => {
     }
   });
 
+  test('migration v19->v20 disables the default Warning/Error rules but leaves custom rules untouched', () => {
+    // The two starter rules now ship disabled. Existing users get them switched
+    // off too; any rule they added themselves (matched by a different name) is
+    // left exactly as it was.
+    const v19Input = {
+      version: 19,
+      profiles: [
+        {
+          name: 'p1',
+          rootConfig: {
+            settings: {
+              rulesSettings: {
+                rules: [
+                  { name: 'Warning', enabled: true },
+                  { name: 'Error', enabled: true },
+                  { name: 'My custom rule', enabled: true },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      currentAppConfig: {
+        settings: {
+          rulesSettings: {
+            rules: [
+              { name: 'Warning', enabled: true },
+              { name: 'Error', enabled: true },
+            ],
+          },
+        },
+      },
+    };
+
+    const { appData, wasChanged, unknownVersion } = migrateAppData(v19Input);
+
+    expect(unknownVersion).toBe(false);
+    expect(wasChanged).toBe(true);
+    expect(appData.version).toBe(LATEST_VERSION);
+
+    const profileRules = appData.profiles?.[0].rootConfig?.settings?.rulesSettings?.rules;
+    expect(profileRules?.find((r: any) => r.name === 'Warning')?.enabled).toBe(false);
+    expect(profileRules?.find((r: any) => r.name === 'Error')?.enabled).toBe(false);
+    // Custom rule is left enabled.
+    expect(profileRules?.find((r: any) => r.name === 'My custom rule')?.enabled).toBe(true);
+
+    const currentRules = appData.currentAppConfig?.settings?.rulesSettings?.rules;
+    expect(currentRules?.every((r: any) => r.enabled === false)).toBe(true);
+  });
+
   test('pushRttRecentDevice persists across a reload of AppDataManager', () => {
     // Regression test: `_loadConfig` used to call `applySocketConnTimeout` / `applyRttSpeed`
     // mid-load, both of which save. Because they ran *before* `rttRecentDevices` was read

--- a/src/renderer/src/model/AppDataManager/DataClasses/HighlightRuleData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/HighlightRuleData.ts
@@ -51,12 +51,17 @@ export class HighlightRuleData {
  *
  * Case-insensitive (the default) so `Warning`, `WARNING`, and `warning`
  * all match without users having to write regex flags themselves.
+ *
+ * Both ship DISABLED by default — they're handy templates, but few users
+ * want their logs auto-highlighted out of the box. Existing users get them
+ * switched off too via `migrateV20toV21`.
  */
 export function makeDefaultHighlightRules(): HighlightRuleData[] {
   // Both default rules use LINE scope (inherited from the POD field
   // initializer) so a matching log line lights up across wrap segments.
   const warning = new HighlightRuleData();
   warning.name = 'Warning';
+  warning.enabled = false;
   warning.pattern = 'warning';
   // Material deep-orange 900. Contrast vs white text ≈ 6.7:1 —
   // comfortably above WCAG AA (4.5:1). The vivid #ff9800 we started
@@ -66,6 +71,7 @@ export function makeDefaultHighlightRules(): HighlightRuleData[] {
 
   const error = new HighlightRuleData();
   error.name = 'Error';
+  error.enabled = false;
   error.pattern = 'error';
   // Material red 900. Contrast vs white text ≈ 7.9:1, clearly red.
   error.backgroundColor = '#b71c1c';

--- a/src/renderer/src/model/AppDataManager/appDataMigrations.ts
+++ b/src/renderer/src/model/AppDataManager/appDataMigrations.ts
@@ -540,13 +540,28 @@ function migrateV18toV19(appData: MigrationAppData): void {
 }
 
 function migrateV19toV20(appData: MigrationAppData): void {
-  // Add the backspace handling setting. Existing configs adopt the new default
-  // (destructive backspace) so that received/echoed 0x08 and 0x7F bytes erase a
-  // character rather than printing a control glyph.
+  // (1) Add the backspace handling setting. Existing configs adopt the new
+  // default (destructive backspace) so that received/echoed 0x08 and 0x7F bytes
+  // erase a character rather than printing a control glyph.
+  //
+  // (2) The two starter highlight rules (Warning / Error) now ship disabled —
+  // see `makeDefaultHighlightRules`. Most users never customised them and few
+  // want their logs auto-highlighted by default, so switch the defaults off for
+  // existing users. Matched by name so any rules the user added themselves are
+  // left untouched.
   forEachRootConfig(appData, (rootConfig) => {
     rootConfig.settings = rootConfig.settings ?? {};
     rootConfig.settings.rxSettings = rootConfig.settings.rxSettings ?? {};
     rootConfig.settings.rxSettings.backspaceBehavior = BackspaceBehavior.DELETE_CHAR;
+
+    const rules = rootConfig.settings.rulesSettings?.rules;
+    if (rules !== undefined) {
+      for (const rule of rules) {
+        if (rule.name === 'Warning' || rule.name === 'Error') {
+          rule.enabled = false;
+        }
+      }
+    }
   });
   appData.version = 20;
 }


### PR DESCRIPTION
The two starter highlight rules now ship disabled - few users want their logs auto-highlighted out of the box. makeDefaultHighlightRules sets enabled=false; existing users have the named Warning/Error rules switched off via the (unreleased) v19->v20 AppData migration, leaving any custom rules untouched.