### PR TITLE
Add form feed (FF, 0x0C) clear-screen handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- **Form feed (FF, 0x0C) clear-screen handling.** New RX "Form Feed" setting with three behaviors — display as glyph (default), clear the screen (keep scrollback), or clear screen and scrollback. Handled in `SingleTerminal._parseAsciiData` reusing the new `_eraseVisibleScreen` helper; AppData migrated v20→v21.
+
 ## [5.14.0] - 2026-06-12
 
 ### Added

--- a/src/renderer/src/model/AppDataManager/DataClasses/AppData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/AppData.ts
@@ -3,7 +3,7 @@ import { makeAutoObservable } from "mobx";
 import { Profile } from "./Profile";
 import { ProfileConfig } from "./ProfileConfig";
 
-export const LATEST_VERSION = 20;
+export const LATEST_VERSION = 21;
 
 export class AppData {
   // Version of the AppData class.

--- a/src/renderer/src/model/AppDataManager/DataClasses/RxSettingsData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/RxSettingsData.ts
@@ -1,4 +1,4 @@
-import { BackspaceBehavior, CarriageReturnCursorBehavior, DataType, Endianness, FloatStringConversionMethod, HexCase, NewLineCursorBehavior, NewLinePlacementOnHexValue, NonVisibleCharDisplayBehaviors, NumberType, PaddingCharacter, TimestampFormat } from "src/model/Settings/RxSettings/RxSettings";
+import { BackspaceBehavior, CarriageReturnCursorBehavior, DataType, Endianness, FloatStringConversionMethod, FormFeedBehavior, HexCase, NewLineCursorBehavior, NewLinePlacementOnHexValue, NonVisibleCharDisplayBehaviors, NumberType, PaddingCharacter, TimestampFormat } from "src/model/Settings/RxSettings/RxSettings";
 
 /**
  * The most up-to-date representation of the RxSettings data stored in the browser's local storage.
@@ -18,6 +18,7 @@ export class RxSettingsData {
   carriageReturnCursorBehavior = CarriageReturnCursorBehavior.DO_NOTHING;
   swallowCarriageReturn = true;
   backspaceBehavior = BackspaceBehavior.DELETE_CHAR;
+  formFeedBehavior = FormFeedBehavior.DO_NOTHING;
   nonVisibleCharDisplayBehavior = NonVisibleCharDisplayBehaviors.ASCII_CONTROL_GLYPHS_AND_HEX_GLYPHS;
 
   // NUMBER-SPECIFIC SETTINGS

--- a/src/renderer/src/model/AppDataManager/appDataMigrations.ts
+++ b/src/renderer/src/model/AppDataManager/appDataMigrations.ts
@@ -25,7 +25,7 @@
 
 import { ConnState, ConnectionType, PortSettings } from '../Settings/PortSettings/PortSettings';
 import DisplaySettings, { TerminalHeightMode } from '../Settings/DisplaySettings/DisplaySettings';
-import { BackspaceBehavior, TimestampFormat } from '../Settings/RxSettings/RxSettings';
+import { BackspaceBehavior, FormFeedBehavior, TimestampFormat } from '../Settings/RxSettings/RxSettings';
 import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TX_COLOR, DEFAULT_RX_COLOR } from './DataClasses/DisplaySettingsData';
 import { LATEST_VERSION } from './DataClasses/AppData';
 import { makeDefaultHighlightRules } from './DataClasses/HighlightRuleData';
@@ -95,6 +95,8 @@ type MigrationRxSettings = {
   version?: number;
   // v19->v20 (added)
   backspaceBehavior?: BackspaceBehavior;
+  // v20->v21 (added)
+  formFeedBehavior?: FormFeedBehavior;
 };
 
 type MigrationTxSettings = {
@@ -566,6 +568,18 @@ function migrateV19toV20(appData: MigrationAppData): void {
   appData.version = 20;
 }
 
+function migrateV20toV21(appData: MigrationAppData): void {
+  // Add the form-feed handling setting. Existing configs adopt the new default
+  // (DO_NOTHING) so a received form feed (FF, 0x0C) continues to be displayed
+  // as a control glyph / swallowed rather than suddenly clearing the screen.
+  forEachRootConfig(appData, (rootConfig) => {
+    rootConfig.settings = rootConfig.settings ?? {};
+    rootConfig.settings.rxSettings = rootConfig.settings.rxSettings ?? {};
+    rootConfig.settings.rxSettings.formFeedBehavior = FormFeedBehavior.DO_NOTHING;
+  });
+  appData.version = 21;
+}
+
 /**
  * Ordered table of migrations. Each entry knows the version it consumes; the
  * loop in `migrateAppData` runs them in order while the data's version is
@@ -592,6 +606,7 @@ const MIGRATIONS: ReadonlyArray<{ from: number; apply: (appData: MigrationAppDat
   { from: 17, apply: migrateV17toV18 },
   { from: 18, apply: migrateV18toV19 },
   { from: 19, apply: migrateV19toV20 },
+  { from: 20, apply: migrateV20toV21 },
 ];
 
 // --------------------------------------------------------------------------

--- a/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
+++ b/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
@@ -38,6 +38,21 @@ export enum BackspaceBehavior {
 }
 
 /**
+ * How to handle a received form-feed (FF, 0x0C) byte.
+ */
+export enum FormFeedBehavior {
+  // Don't treat it specially; the byte is rendered/swallowed like any other
+  // non-visible char (per the non-visible char display setting). This is the
+  // standards-correct default (ECMA-48/VT100 do not clear the screen on FF).
+  DO_NOTHING,
+  // Erase the visible screen but keep the scrollback buffer (equivalent to the
+  // ANSI ESC[2J erase-in-display sequence).
+  CLEAR_SCREEN,
+  // Erase the visible screen and the scrollback buffer (equivalent to ESC[3J).
+  CLEAR_SCREEN_AND_SCROLLBACK,
+}
+
+/**
  * Enumerates the possible behaviors for displaying non-visible
  * characters in the terminal. Non-visible is any byte from 0x00-0xFF
  * which is not a visible ASCII character.
@@ -129,6 +144,7 @@ export default class RxSettings {
   carriageReturnCursorBehavior = CarriageReturnCursorBehavior.DO_NOTHING;
   swallowCarriageReturn = true;
   backspaceBehavior = BackspaceBehavior.DELETE_CHAR;
+  formFeedBehavior = FormFeedBehavior.DO_NOTHING;
   nonVisibleCharDisplayBehavior = NonVisibleCharDisplayBehaviors.ASCII_CONTROL_GLYPHS_AND_HEX_GLYPHS;
 
   // NUMBER-SPECIFIC SETTINGS
@@ -217,6 +233,7 @@ export default class RxSettings {
     this.carriageReturnCursorBehavior = configToLoad.carriageReturnCursorBehavior;
     this.swallowCarriageReturn = configToLoad.swallowCarriageReturn;
     this.backspaceBehavior = configToLoad.backspaceBehavior;
+    this.formFeedBehavior = configToLoad.formFeedBehavior;
     this.nonVisibleCharDisplayBehavior = configToLoad.nonVisibleCharDisplayBehavior;
 
     // NUMBER-SPECIFIC SETTINGS
@@ -273,6 +290,7 @@ export default class RxSettings {
     config.carriageReturnCursorBehavior = this.carriageReturnCursorBehavior;
     config.swallowCarriageReturn = this.swallowCarriageReturn;
     config.backspaceBehavior = this.backspaceBehavior;
+    config.formFeedBehavior = this.formFeedBehavior;
     config.nonVisibleCharDisplayBehavior = this.nonVisibleCharDisplayBehavior;
 
     // NUMBER-SPECIFIC SETTINGS
@@ -348,6 +366,11 @@ export default class RxSettings {
 
   setBackspaceBehavior = (value: BackspaceBehavior) => {
     this.backspaceBehavior = value;
+    this._saveConfig();
+  };
+
+  setFormFeedBehavior = (value: FormFeedBehavior) => {
+    this.formFeedBehavior = value;
     this._saveConfig();
   };
 

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
@@ -4,6 +4,7 @@ import { stringToUint8Array } from 'src/model/Util/Util';
 import { DataDirection, SingleTerminal, START_OF_HEX_GLYPHS } from './SingleTerminal';
 import RxSettings, {
   BackspaceBehavior,
+  FormFeedBehavior,
   NewLineCursorBehavior,
   NonVisibleCharDisplayBehaviors,
   TimestampFormat,
@@ -884,6 +885,65 @@ describe('single terminal tests', () => {
 
       expect(singleTerminal.cursorPosition).toEqual([0, 0]);
       expect(singleTerminal.terminalRows[0].terminalChars.length).toBe(1);
+    });
+  });
+
+  //================================================================================
+  // Form feed handling
+  //================================================================================
+  describe('form feed handling', () => {
+    test('DO_NOTHING (default) renders the form feed as a control glyph', () => {
+      // DO_NOTHING is the default behavior, so a received FF is shown as a glyph
+      // like any other non-visible char rather than clearing the screen.
+      singleTerminal.parseData(stringToUint8Array('a\f'), DataDirection.RX);
+
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars[0].char).toBe('a');
+      // 0x0C shifted up into the control-glyph PUA range.
+      expect(chars[1].char).toBe(String.fromCharCode(0x0c + 0xe000));
+    });
+
+    test('CLEAR_SCREEN_AND_SCROLLBACK resets the terminal like clear()', () => {
+      dataProcessingSettings.setFormFeedBehavior(FormFeedBehavior.CLEAR_SCREEN_AND_SCROLLBACK);
+      singleTerminal.parseData(stringToUint8Array('row1\nrow2\fabc'), DataDirection.RX);
+
+      // Scrollback ('row1') is gone; only the post-FF content remains, starting
+      // at the top of a fresh terminal.
+      expect(singleTerminal.terminalRows.length).toBe(1);
+      const chars = singleTerminal.terminalRows[0].terminalChars;
+      expect(chars[0].char).toBe('a');
+      expect(chars[1].char).toBe('b');
+      expect(chars[2].char).toBe('c');
+      expect(singleTerminal.cursorPosition).toEqual([0, 3]);
+    });
+
+    test('CLEAR_SCREEN is equivalent to the ANSI ESC[2J sequence', () => {
+      // FF with CLEAR_SCREEN should leave the terminal in the same state as
+      // sending the same data followed by an ESC[2J erase-in-display sequence.
+      dataProcessingSettings.setFormFeedBehavior(FormFeedBehavior.CLEAR_SCREEN);
+      singleTerminal.parseData(stringToUint8Array('abc\f'), DataDirection.RX);
+      const ffState = JSON.stringify(singleTerminal.terminalRows);
+      const ffCursor = singleTerminal.cursorPosition;
+
+      // Re-run with an explicit ESC[2J instead of the form feed.
+      singleTerminal.clear();
+      dataProcessingSettings.setFormFeedBehavior(FormFeedBehavior.DO_NOTHING);
+      singleTerminal.parseData(stringToUint8Array('abc\x1b[2J'), DataDirection.RX);
+
+      expect(JSON.stringify(singleTerminal.terminalRows)).toBe(ffState);
+      expect(singleTerminal.cursorPosition).toEqual(ffCursor);
+    });
+
+    test('a form feed mid-escape-sequence is not treated as a clear', () => {
+      // 0x0C appearing inside an (incomplete) escape sequence must not trigger
+      // the clear behavior.
+      dataProcessingSettings.setFormFeedBehavior(FormFeedBehavior.CLEAR_SCREEN_AND_SCROLLBACK);
+      singleTerminal.parseData(stringToUint8Array('row1\nrow2'), DataDirection.RX);
+      // ESC then FF — the FF is consumed as part of escape-code parsing, not a clear.
+      singleTerminal.parseData(new Uint8Array([0x1b, 0x0c]), DataDirection.RX);
+
+      // The two rows are still present (nothing was cleared).
+      expect(singleTerminal.terminalRows.length).toBe(2);
     });
   });
 

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
@@ -12,6 +12,7 @@ import RxSettings, {
   DataType,
   Endianness,
   FloatStringConversionMethod,
+  FormFeedBehavior,
   HexCase,
   NewLineCursorBehavior,
   NewLinePlacementOnHexValue,
@@ -852,6 +853,30 @@ export class SingleTerminal {
         continue;
       }
 
+      //========================================================================
+      // FORM FEED HANDLING
+      //========================================================================
+      // 0x0C is ASCII form feed (\f, Ctrl-L). It is not a screen-clear under
+      // ECMA-48/VT100, but many embedded devices send a bare FF expecting the
+      // terminal to clear, so this is offered as an opt-in behavior. When the
+      // behavior is DO_NOTHING we fall through and the byte is
+      // rendered/swallowed like any other non-visible char.
+      const formFeedBehavior = this.rxSettings.formFeedBehavior;
+      if (
+        this.inIdleState &&
+        rxByte === 0x0c &&
+        formFeedBehavior !== FormFeedBehavior.DO_NOTHING
+      ) {
+        if (formFeedBehavior === FormFeedBehavior.CLEAR_SCREEN) {
+          this._eraseVisibleScreen();
+        } else if (formFeedBehavior === FormFeedBehavior.CLEAR_SCREEN_AND_SCROLLBACK) {
+          this.clear();
+        } else {
+          throw Error('Invalid form feed behavior. formFeedBehavior=' + formFeedBehavior);
+        }
+        continue;
+      }
+
       if (rxByte === 0x1b) {
         this._resetEscapeCodeParserState();
         this.inAnsiEscapeCode = true;
@@ -1036,29 +1061,8 @@ export class SingleTerminal {
           currRow.terminalChars[charIdx].style = {};
         }
       } else if (numberN === 2) {
-        // Erase entire screen
-        // User could be scrolled anywhere in the scrollback buffer, we don't want to just
-        // clear the rows being displayed.
-        // 1. Clear all data at or after cursor
-        // 2. Move cursor down one row to new row
-        // 3. Insert enough empty rows after row with cursor to fill the screen
-        this._clearDataFromCursorToEndOfScreen();
-        this._cursorDown(1);
-        // Add empty rows to fill the entire terminal (ignoring scrollback buffer)
-        // Subtract 1 because we already added a row with the cursor
-        const numRowsToAdd = this.terminalHeightChars - 1;
-        // Might not need to add any rows if terminal height is very small
-        // (or 0 if hidden)
-        if (numRowsToAdd > 0) {
-          for (let idx = 0; idx < numRowsToAdd; idx += 1) {
-            this.terminalRows.push(new TerminalRow(this.uniqueRowIndexCount, false));
-            this.uniqueRowIndexCount += 1;
-            // Add to filtered rows if new rows match the filter
-            if (this._doesRowPassFilter(this.terminalRows.length - 1)) {
-              // filteredTerminalRows is now computed automatically
-            }
-          }
-        }
+        // Erase entire screen (visible screen only, scrollback is kept).
+        this._eraseVisibleScreen();
       } else if (numberN === 3) {
         // Clear entire screen and delete all lines saved in the scrollback buffer
         this.clear();
@@ -1188,6 +1192,37 @@ export class SingleTerminal {
     }
     // Now remove all rows past the one the cursor is on
     this.terminalRows.splice(this.cursorPosition[0] + 1);
+  }
+
+  /**
+   * Erase the visible screen while keeping the scrollback buffer, equivalent to
+   * the ANSI ESC[2J erase-in-display sequence. Used by both the ED CSI handler
+   * and the form-feed (FF, 0x0C) clear-screen behavior.
+   *
+   * The user could be scrolled anywhere in the scrollback buffer, so we don't
+   * just clear the rows currently being displayed:
+   * 1. Clear all data at or after the cursor.
+   * 2. Move the cursor down one row to a new row.
+   * 3. Insert enough empty rows after the cursor row to fill the screen.
+   */
+  _eraseVisibleScreen() {
+    this._clearDataFromCursorToEndOfScreen();
+    this._cursorDown(1);
+    // Add empty rows to fill the entire terminal (ignoring scrollback buffer).
+    // Subtract 1 because we already added a row with the cursor.
+    const numRowsToAdd = this.terminalHeightChars - 1;
+    // Might not need to add any rows if terminal height is very small
+    // (or 0 if hidden)
+    if (numRowsToAdd > 0) {
+      for (let idx = 0; idx < numRowsToAdd; idx += 1) {
+        this.terminalRows.push(new TerminalRow(this.uniqueRowIndexCount, false));
+        this.uniqueRowIndexCount += 1;
+        // Add to filtered rows if new rows match the filter
+        if (this._doesRowPassFilter(this.terminalRows.length - 1)) {
+          // filteredTerminalRows is now computed automatically
+        }
+      }
+    }
   }
 
   /**

--- a/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
@@ -7,6 +7,7 @@ import RxSettings, {
   DataType,
   Endianness,
   FloatStringConversionMethod,
+  FormFeedBehavior,
   HexCase,
   NewLineCursorBehavior,
   NewLinePlacementOnHexValue,
@@ -330,6 +331,54 @@ function RxSettingsView(props: Props) {
                   {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
                 >
                   <FormControlLabel value={BackspaceBehavior.DELETE_CHAR} control={<Radio />} label="Move the cursor one column to the left and delete the character" />
+                </Tooltip>
+              </RadioGroup>
+            </FormControl>
+          </div>
+        </BorderedSection>
+        {/* =============================================================================== */}
+        {/* FORM FEED SETTINGS */}
+        {/* =============================================================================== */}
+        <BorderedSection title="Form Feed">
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              maxWidth: '600px',
+              gap: '20px',
+            }}
+          >
+            <FormControl sx={{ width: 'fit-content' }}>
+              <FormLabel>When a form feed (0x0C, \f, Ctrl-L) byte is received:</FormLabel>
+              <RadioGroup
+                value={rxSettings.formFeedBehavior}
+                onChange={(e) => {
+                  rxSettings.setFormFeedBehavior(parseInt(e.target.value));
+                }}
+              >
+                {/* DO NOTHING */}
+                <Tooltip
+                  title="Don't interpret form feed bytes. They are displayed as a control glyph (or swallowed) just like any other non-visible character, per the setting below. This is the standards-correct behavior (ECMA-48/VT100 do not clear the screen on form feed)."
+                  placement="right"
+                  {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+                >
+                  <FormControlLabel value={FormFeedBehavior.DO_NOTHING} control={<Radio />} label="Don't interpret (display as a glyph)" />
+                </Tooltip>
+                {/* CLEAR SCREEN */}
+                <Tooltip
+                  title="Erase the visible screen but keep the scrollback buffer (equivalent to the ANSI ESC[2J sequence). Useful for embedded devices that send a bare form feed to clear the terminal."
+                  placement="right"
+                  {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+                >
+                  <FormControlLabel value={FormFeedBehavior.CLEAR_SCREEN} control={<Radio />} label="Clear the screen (keep scrollback)" />
+                </Tooltip>
+                {/* CLEAR SCREEN AND SCROLLBACK */}
+                <Tooltip
+                  title="Erase the visible screen and the scrollback buffer (equivalent to the ANSI ESC[3J sequence)."
+                  placement="right"
+                  {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+                >
+                  <FormControlLabel value={FormFeedBehavior.CLEAR_SCREEN_AND_SCROLLBACK} control={<Radio />} label="Clear the screen and scrollback" />
                 </Tooltip>
               </RadioGroup>
             </FormControl>


### PR DESCRIPTION
## Summary

Adds an opt-in RX **Form Feed** setting so a received form feed (FF, 0x0C / `\f` / Ctrl-L) can clear the terminal — a common convention for embedded devices that can't run readline/ncurses and just blast a bare FF to wipe the screen.

Off by default to preserve standard VT behavior, since clearing on FF isn't an ANSI/VT100 standard (ECMA-48 treats FF as a format effector ≈ line feed).

## Behaviors

- **Don't interpret (display as a glyph)** — default; FF renders like any other non-visible char
- **Clear the screen (keep scrollback)** — equivalent to ANSI `ESC[2J`
- **Clear the screen and scrollback** — equivalent to `ESC[3J`

## Implementation notes

- Handled in `SingleTerminal._parseAsciiData`, only in ASCII mode and only when the parser is idle (an FF arriving mid-escape-sequence is consumed by the escape parser, not treated as a clear).
- Extracted the existing `ESC[2J` erase logic into a reusable `_eraseVisibleScreen()` helper so FF and the ANSI sequence share one code path.
- AppData migrated **v20→v21**; existing users default to `DO_NOTHING`.

## Testing

- `npm run test:unit` — **250 passed** (incl. 4 new form-feed tests: glyph default, full clear, ESC[2J equivalence, mid-escape FF ignored)
- `npx tsc` — clean

Addresses user feedback suggestion (use ASCII FF as a clear-screen option in ASCII mode).