### PR TITLE
Surface unknown ANSI escape sequences inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Form feed (FF, 0x0C) clear-screen handling.** New RX "Form Feed" setting with three behaviors — display as glyph (default), clear the screen (keep scrollback), or clear screen and scrollback. Handled in `SingleTerminal._parseAsciiData` reusing the new `_eraseVisibleScreen` helper; AppData migrated v20→v21.
 - **Surface unknown ANSI escape sequences.** New opt-in RX "Show Unknown Escape Codes" setting renders unsupported/malformed CSI sequences (e.g. `ESC[K`, `ESC[6n`, unsupported SGR codes) inline as a highlighted `unknown-escape` marker instead of silently dropping them, via `SingleTerminal._surfaceUnknownEscapeCode`; setting added to the v20→v21 AppData migration.
+- **Fake port "unsupported escape codes"** that streams a rotating set of CSI sequences NinjaTerm doesn't support and auto-enables "Show Unknown Escape Codes", for testing the surfacing feature.
+- **Search box in the fake port selection dialog** to filter the (now long) list by name/description.
 
 ## [5.14.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **Form feed (FF, 0x0C) clear-screen handling.** New RX "Form Feed" setting with three behaviors — display as glyph (default), clear the screen (keep scrollback), or clear screen and scrollback. Handled in `SingleTerminal._parseAsciiData` reusing the new `_eraseVisibleScreen` helper; AppData migrated v20→v21.
+- **Surface unknown ANSI escape sequences.** New opt-in RX "Show Unknown Escape Codes" setting renders unsupported/malformed CSI sequences (e.g. `ESC[K`, `ESC[6n`, unsupported SGR codes) inline as a highlighted `unknown-escape` marker instead of silently dropping them, via `SingleTerminal._surfaceUnknownEscapeCode`; setting added to the v20→v21 AppData migration.
 
 ## [5.14.0] - 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ npx tsc
 
 If updating any settings that are stored in the app data, make sure to add the migration code to the app data manager.
 
+Only bump the app data version (`LATEST_VERSION`) once per release. If the latest migration is still unreleased (i.e. `package.json` `version` hasn't shipped with the current `LATEST_VERSION` yet), fold new schema changes into that existing migration function rather than adding a new version step. Only add a fresh migration + `LATEST_VERSION` bump once the current version has actually been released.
+
 Don't update the NinjaTerm application under web/, this is in maintenance mode and not updated unless it's a critical bug.
 
 When making changes that affect behaviour — features, bug fixes, performance changes, dependency drops, anything user- or developer-visible — add a corresponding entry to the `## Unreleased` section of `CHANGELOG.md` under `### Added` / `### Changed` / `### Fixed` as appropriate. Do this in the same PR as the change, not as a separate follow-up — once it's merged the context fades and the entry never gets written. Internal-only refactors with zero outward impact (e.g. renaming a private helper) don't need a CHANGELOG entry.

--- a/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
+++ b/src/renderer/src/model/AppDataManager/AppDataManager.spec.ts
@@ -108,9 +108,7 @@ describe('app data manager tests', () => {
     updateAndCompare(savedAppData);
   });
 
-  test('app data can be loaded from v20 (current version)', () => {
-    // v20 is the current LATEST_VERSION, so no migration runs — this guards
-    // that the saved default snapshot still deserialises to a fresh AppData.
+  test('app data can be upgraded from v20', () => {
     const savedAppData = JSON.parse(fs.readFileSync('./local-storage-data/appData-v20-app-v5.14.0-default.json', 'utf8'));
     updateAndCompare(savedAppData);
   });

--- a/src/renderer/src/model/AppDataManager/DataClasses/RxSettingsData.ts
+++ b/src/renderer/src/model/AppDataManager/DataClasses/RxSettingsData.ts
@@ -12,6 +12,7 @@ export class RxSettingsData {
   // ASCII-SPECIFIC SETTINGS
   ansiEscapeCodeParsingEnabled = true;
   maxEscapeCodeLengthChars = 10;
+  showUnknownEscapeCodes = false;
   localTxEcho = false;
   newLineCursorBehavior = NewLineCursorBehavior.CARRIAGE_RETURN_AND_NEW_LINE;
   swallowNewLine = true;

--- a/src/renderer/src/model/AppDataManager/appDataMigrations.ts
+++ b/src/renderer/src/model/AppDataManager/appDataMigrations.ts
@@ -97,6 +97,7 @@ type MigrationRxSettings = {
   backspaceBehavior?: BackspaceBehavior;
   // v20->v21 (added)
   formFeedBehavior?: FormFeedBehavior;
+  showUnknownEscapeCodes?: boolean;
 };
 
 type MigrationTxSettings = {
@@ -569,13 +570,20 @@ function migrateV19toV20(appData: MigrationAppData): void {
 }
 
 function migrateV20toV21(appData: MigrationAppData): void {
-  // Add the form-feed handling setting. Existing configs adopt the new default
-  // (DO_NOTHING) so a received form feed (FF, 0x0C) continues to be displayed
-  // as a control glyph / swallowed rather than suddenly clearing the screen.
+  // (1) Add the form-feed handling setting. Existing configs adopt the new
+  // default (DO_NOTHING) so a received form feed (FF, 0x0C) continues to be
+  // displayed as a control glyph / swallowed rather than suddenly clearing the
+  // screen.
+  //
+  // (2) Add the show-unknown-escape-codes setting. Existing configs adopt the
+  // new default (false) so unsupported/malformed CSI escape sequences continue
+  // to be silently discarded rather than suddenly appearing inline in the
+  // terminal. Users opt in for troubleshooting.
   forEachRootConfig(appData, (rootConfig) => {
     rootConfig.settings = rootConfig.settings ?? {};
     rootConfig.settings.rxSettings = rootConfig.settings.rxSettings ?? {};
     rootConfig.settings.rxSettings.formFeedBehavior = FormFeedBehavior.DO_NOTHING;
+    rootConfig.settings.rxSettings.showUnknownEscapeCodes = false;
   });
   appData.version = 21;
 }

--- a/src/renderer/src/model/FakePorts/FakePortsController.tsx
+++ b/src/renderer/src/model/FakePorts/FakePortsController.tsx
@@ -43,6 +43,12 @@ export default class FakePortsController {
 
   fakePortOpen = false;
 
+  /**
+   * Free-text filter applied to the fake port list in the selection dialog.
+   * Matches against both the name and description (case-insensitive).
+   */
+  searchText = '';
+
   constructor(app: App) {
     this.app = app;
 
@@ -560,6 +566,60 @@ export default class FakePortsController {
           app.parseRxData(Uint8Array.from(bytesToSend));
 
           return null;
+        },
+        (intervalId: NodeJS.Timeout | null) => {
+          // Stop the interval
+          if (intervalId !== null) {
+            clearInterval(intervalId);
+          }
+        }
+      )
+    );
+
+    //=================================================================================
+    // unsupported/unknown escape codes (for testing "Show Unknown Escape Codes")
+    //=================================================================================
+    this.fakePorts.push(
+      new FakePort(
+        'unsupported escape codes, ~0.7lps',
+        'Sends a rotating set of CSI escape sequences that NinjaTerm does not support (erase line, cursor moves, DSR, show/hide cursor, save/restore cursor, italic/underline/inverse, 256-colour and true-colour SGR). Enables ANSI parsing and the RX "Show Unknown Escape Codes" setting so each unsupported sequence is surfaced inline as a highlighted marker.',
+        () => {
+          app.settings.rxSettings.setAnsiEscapeCodeParsingEnabled(true);
+          app.settings.rxSettings.setShowUnknownEscapeCodes(true);
+          // Some demo sequences are longer than the default 10-char limit (e.g.
+          // true-colour SGR), so raise it enough that they are parsed as a
+          // single sequence rather than being truncated mid-code.
+          app.settings.rxSettings.maxEscapeCodeLengthChars.setDispValue('25');
+          app.settings.rxSettings.maxEscapeCodeLengthChars.apply();
+
+          // Each line is a human-readable label followed by the raw, unsupported
+          // escape sequence — the sequence itself is what gets surfaced.
+          const strings = [
+            'EL erase line (ESC[K): \x1b[K',
+            'EL erase line n=2 (ESC[2K): \x1b[2K',
+            'CUP cursor home (ESC[H): \x1b[H',
+            'CUP cursor position (ESC[5;10H): \x1b[5;10H',
+            'DSR device status report (ESC[6n): \x1b[6n',
+            'show cursor (ESC[?25h): \x1b[?25h',
+            'hide cursor (ESC[?25l): \x1b[?25l',
+            'SCP save cursor (ESC[s): \x1b[s',
+            'RCP restore cursor (ESC[u): \x1b[u',
+            'SGR italic (ESC[3m): \x1b[3mitalic?\x1b[0m',
+            'SGR underline (ESC[4m): \x1b[4munderline?\x1b[0m',
+            'SGR inverse (ESC[7m): \x1b[7minverse?\x1b[0m',
+            'SGR 256-colour fg (ESC[38;5;82m): \x1b[38;5;82mgreen?\x1b[0m',
+            'SGR true-colour fg (ESC[38;2;0;200;0m): \x1b[38;2;0;200;0mgreen?\x1b[0m',
+          ];
+          let stringIdx = 0;
+          const intervalId = setInterval(() => {
+            const textToSend = strings[stringIdx] + '\n';
+            app.parseRxData(new TextEncoder().encode(textToSend));
+            stringIdx += 1;
+            if (stringIdx === strings.length) {
+              stringIdx = 0;
+            }
+          }, 1500);
+          return intervalId;
         },
         (intervalId: NodeJS.Timeout | null) => {
           // Stop the interval
@@ -1456,6 +1516,28 @@ export default class FakePortsController {
 
   setIsDialogOpen(isDialogOpen: boolean) {
     this.isDialogOpen = isDialogOpen;
+  }
+
+  setSearchText(searchText: string) {
+    this.searchText = searchText;
+  }
+
+  /**
+   * The fake ports matching the current search text, each paired with its
+   * original index into `fakePorts`. The original index is preserved because
+   * selection (`selFakePortIdx`) and `openPort()` both index into the full,
+   * unfiltered array.
+   */
+  get filteredFakePorts(): { fakePort: FakePort; idx: number }[] {
+    const withIdx = this.fakePorts.map((fakePort, idx) => ({ fakePort, idx }));
+    const search = this.searchText.trim().toLowerCase();
+    if (search === '') {
+      return withIdx;
+    }
+    return withIdx.filter(
+      ({ fakePort }) =>
+        fakePort.name.toLowerCase().includes(search) || fakePort.description.toLowerCase().includes(search)
+    );
   }
 
   onClick(fakePortIdx: number) {

--- a/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
+++ b/src/renderer/src/model/Settings/RxSettings/RxSettings.ts
@@ -138,6 +138,11 @@ export default class RxSettings {
   // ASCII-SPECIFIC SETTINGS
   ansiEscapeCodeParsingEnabled = true;
   maxEscapeCodeLengthChars = new ApplyableNumberField("10", z.coerce.number().min(2));
+  // When enabled, CSI escape sequences that are received but not supported (or
+  // are malformed) are rendered inline in the terminal as a highlighted marker
+  // rather than being silently discarded. A troubleshooting aid, off by default
+  // so normal output is unaffected.
+  showUnknownEscapeCodes = false;
   localTxEcho = false;
   newLineCursorBehavior = NewLineCursorBehavior.CARRIAGE_RETURN_AND_NEW_LINE;
   swallowNewLine = true;
@@ -227,6 +232,7 @@ export default class RxSettings {
     this.ansiEscapeCodeParsingEnabled = configToLoad.ansiEscapeCodeParsingEnabled;
     this.maxEscapeCodeLengthChars.setDispValue(configToLoad.maxEscapeCodeLengthChars.toString());
     this.maxEscapeCodeLengthChars.apply();
+    this.showUnknownEscapeCodes = configToLoad.showUnknownEscapeCodes;
     this.localTxEcho = configToLoad.localTxEcho;
     this.newLineCursorBehavior = configToLoad.newLineCursorBehavior;
     this.swallowNewLine = configToLoad.swallowNewLine;
@@ -284,6 +290,7 @@ export default class RxSettings {
     // ASCII-SPECIFIC SETTINGS
     config.ansiEscapeCodeParsingEnabled = this.ansiEscapeCodeParsingEnabled;
     config.maxEscapeCodeLengthChars = this.maxEscapeCodeLengthChars.appliedValue;
+    config.showUnknownEscapeCodes = this.showUnknownEscapeCodes;
     config.localTxEcho = this.localTxEcho;
     config.newLineCursorBehavior = this.newLineCursorBehavior;
     config.swallowNewLine = this.swallowNewLine;
@@ -336,6 +343,11 @@ export default class RxSettings {
 
   setAnsiEscapeCodeParsingEnabled = (value: boolean) => {
     this.ansiEscapeCodeParsingEnabled = value;
+    this._saveConfig();
+  };
+
+  setShowUnknownEscapeCodes = (value: boolean) => {
+    this.showUnknownEscapeCodes = value;
     this._saveConfig();
   };
 

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe, beforeEach } from 'vitest';
 
 import { stringToUint8Array } from 'src/model/Util/Util';
-import { DataDirection, SingleTerminal, START_OF_HEX_GLYPHS } from './SingleTerminal';
+import { DataDirection, SingleTerminal, START_OF_CONTROL_GLYPHS, START_OF_HEX_GLYPHS } from './SingleTerminal';
 import RxSettings, {
   BackspaceBehavior,
   FormFeedBehavior,
@@ -249,6 +249,62 @@ describe('single terminal tests', () => {
       // We expect the class name to be an empty string now, as we have called clear()
       for (let i = 0; i < 7; i++) {
         expect(singleTerminal.terminalRows[0].terminalChars[i].className).not.toContain('f31');
+      }
+    });
+  });
+
+  //================================================================================
+  // Unknown escape code surfacing tests
+  //================================================================================
+  describe('unknown escape code surfacing', () => {
+    const escGlyph = String.fromCharCode(0x1b + START_OF_CONTROL_GLYPHS);
+
+    test('unsupported CSI final byte is surfaced when enabled', () => {
+      dataProcessingSettings.showUnknownEscapeCodes = true;
+      // ESC[6n is the Device Status Report request, which NinjaTerm does not support.
+      singleTerminal.parseData(stringToUint8Array('\x1B[6n'), DataDirection.RX);
+      const row = singleTerminal.terminalRows[0];
+      // ESC, [, 6, n, then the cursor-holder space
+      expect(row.terminalChars.length).toBe(5);
+      expect(row.terminalChars[0].char).toBe(escGlyph);
+      expect(row.terminalChars[1].char).toBe('[');
+      expect(row.terminalChars[2].char).toBe('6');
+      expect(row.terminalChars[3].char).toBe('n');
+      for (let i = 0; i < 4; i++) {
+        expect(row.terminalChars[i].className).toContain('unknown-escape');
+      }
+    });
+
+    test('unsupported CSI final byte is silently discarded when disabled (default)', () => {
+      expect(dataProcessingSettings.showUnknownEscapeCodes).toBe(false);
+      singleTerminal.parseData(stringToUint8Array('\x1B[6n'), DataDirection.RX);
+      const row = singleTerminal.terminalRows[0];
+      // Only the cursor-holder space remains — the sequence was dropped.
+      expect(row.terminalChars.length).toBe(1);
+      expect(row.terminalChars[0].char).toBe(' ');
+    });
+
+    test('unsupported SGR code is surfaced when enabled', () => {
+      dataProcessingSettings.showUnknownEscapeCodes = true;
+      // 99 is not a recognised SGR code.
+      singleTerminal.parseData(stringToUint8Array('\x1B[99m'), DataDirection.RX);
+      const row = singleTerminal.terminalRows[0];
+      // ESC, [, 9, 9, m, then the cursor-holder space
+      expect(row.terminalChars.length).toBe(6);
+      expect(row.terminalChars[0].char).toBe(escGlyph);
+      for (let i = 0; i < 5; i++) {
+        expect(row.terminalChars[i].className).toContain('unknown-escape');
+      }
+    });
+
+    test('supported escape sequence is never surfaced', () => {
+      dataProcessingSettings.showUnknownEscapeCodes = true;
+      singleTerminal.parseData(stringToUint8Array('\x1B[31mred'), DataDirection.RX);
+      const row = singleTerminal.terminalRows[0];
+      // Just "red" + cursor; the recognised colour sequence is applied, not surfaced.
+      expect(row.terminalChars.length).toBe(4);
+      for (const terminalChar of row.terminalChars) {
+        expect(terminalChar.className).not.toContain('unknown-escape');
       }
     });
   });

--- a/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
+++ b/src/renderer/src/model/Terminals/SingleTerminal/SingleTerminal.ts
@@ -908,7 +908,7 @@ export class SingleTerminal {
         if (this.inCSISequence && this.partialEscapeCode.length > 2) {
           const isCsiFinalByte = rxByte >= 0x40 && rxByte <= 0x7e;
           if (isCsiFinalByte) {
-            this._parseCSISequence(String.fromCharCode(...this.partialEscapeCode));
+            this._parseCSISequence(String.fromCharCode(...this.partialEscapeCode), direction);
             this._resetEscapeCodeParserState();
             this.inIdleState = true;
           }
@@ -954,8 +954,10 @@ export class SingleTerminal {
    *
    * @param ansiEscapeCode Must be in the form "ESC[<remaining data>". This function will validate
    *    the rest of the code, and perform actions on the terminal as required.
+   * @param direction The direction (TX/RX) the data came from, used when an
+   *    unsupported/malformed sequence needs to be surfaced inline.
    */
-  _parseCSISequence(ansiEscapeCode: string) {
+  _parseCSISequence(ansiEscapeCode: string, direction: DataDirection) {
     // The last char is used to work out what kind of CSI sequence it is
     const lastChar = ansiEscapeCode.slice(ansiEscapeCode.length - 1);
     //============================================================
@@ -970,7 +972,8 @@ export class SingleTerminal {
       }
       const numRowsToGoUp = parseInt(numberStr, 10);
       if (Number.isNaN(numRowsToGoUp)) {
-        console.error(`Number string in SGR code could not converted into integer. numberStr=${numberStr}.`);
+        console.error(`Number string in CUU (cursor up) CSI sequence could not converted into integer. numberStr=${numberStr}.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
         return;
       }
       this._cursorUp(numRowsToGoUp);
@@ -986,7 +989,8 @@ export class SingleTerminal {
       }
       const numColsToGoRight = parseInt(numberStr, 10);
       if (Number.isNaN(numColsToGoRight)) {
-        console.error(`Number string in SGR code could not converted into integer. numberStr=${numberStr}.`);
+        console.error(`Number string in CUF (cursor forward) CSI sequence could not converted into integer. numberStr=${numberStr}.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
         return;
       }
       this._cursorRight(numColsToGoRight);
@@ -1002,7 +1006,8 @@ export class SingleTerminal {
       }
       const numColsToGoLeft = parseInt(numberStr, 10);
       if (Number.isNaN(numColsToGoLeft)) {
-        console.error(`Number string in SGR code could not converted into integer. numberStr=${numberStr}.`);
+        console.error(`Number string in CUB (cursor back) CSI sequence could not converted into integer. numberStr=${numberStr}.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
         return;
       }
       this._cursorLeft(numColsToGoLeft);
@@ -1024,6 +1029,7 @@ export class SingleTerminal {
       const numberN = parseInt(numberStr, 10);
       if (Number.isNaN(numberN)) {
         console.error(`Number string in Erase in Display (ED) CSI sequence could not converted into integer. numberStr=${numberStr}.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
         return;
       }
       if (numberN === 0) {
@@ -1068,6 +1074,7 @@ export class SingleTerminal {
         this.clear();
       } else {
         console.error(`Number (${numberN}) passed to Erase in Display (ED) CSI sequence not supported.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
       }
     } else if (lastChar === 'm') {
       // SGR
@@ -1087,11 +1094,16 @@ export class SingleTerminal {
       }
       // Split into individual codes
       const numberCodeStrings = numbersAndSemicolons.split(';');
+      // Track whether any individual code was malformed or unsupported, so the
+      // whole sequence can be surfaced once at the end (recognised codes are
+      // still applied).
+      let hadUnsupportedSgrCode = false;
       for (let idx = 0; idx < numberCodeStrings.length; idx += 1) {
         const numberCodeString = numberCodeStrings[idx];
         const numberCode = parseInt(numberCodeString, 10);
         if (Number.isNaN(numberCode)) {
           console.error(`Number string in SGR code could not converted into integer. numberCodeString=${numberCodeString}.`);
+          hadUnsupportedSgrCode = true;
           // Skip processing this number, but continue with the rest
           continue;
         }
@@ -1112,7 +1124,11 @@ export class SingleTerminal {
           this.currBackgroundColorNum = numberCode;
         } else {
           console.log(`Number ${numberCode} provided to SGR control sequence unsupported.`);
+          hadUnsupportedSgrCode = true;
         }
+      }
+      if (hadUnsupportedSgrCode) {
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
       }
     } else if (lastChar === 'P') {
       //============================================================
@@ -1129,9 +1145,40 @@ export class SingleTerminal {
       const numCharsToDelete = parseInt(numberStr, 10);
       if (Number.isNaN(numCharsToDelete)) {
         console.error(`Number string in Delete Character (DCH) CSI sequence could not be converted into integer. numberStr=${numberStr}.`);
+        this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
         return;
       }
       this._deleteChars(numCharsToDelete);
+    } else {
+      // CSI sequence with a final byte we don't support (e.g. ESC[K erase line,
+      // ESC[H cursor position, ESC[6n device status report, ESC[?25h show
+      // cursor, the ESC[n~ nav-key sequences). Surface it inline for
+      // troubleshooting rather than dropping it. No console log here — these can
+      // arrive frequently (e.g. echoed nav keys) and would spam the console;
+      // _surfaceUnknownEscapeCode is gated behind the user setting.
+      this._surfaceUnknownEscapeCode(ansiEscapeCode, direction);
+    }
+  }
+
+  /**
+   * Renders the raw bytes of an unsupported or malformed escape sequence inline
+   * in the terminal, tagged with the `unknown-escape` CSS class so they stand
+   * out from normal output. The ESC byte is rendered as its control glyph so it
+   * is visible. Does nothing unless the user has enabled surfacing of unknown
+   * escape codes — the default is to silently discard them.
+   *
+   * @param ansiEscapeCode The full sequence, in the form "ESC[...".
+   * @param direction The direction (TX/RX) the sequence arrived on.
+   */
+  _surfaceUnknownEscapeCode(ansiEscapeCode: string, direction: DataDirection) {
+    if (!this.rxSettings.showUnknownEscapeCodes) {
+      return;
+    }
+    for (let idx = 0; idx < ansiEscapeCode.length; idx += 1) {
+      this._maybeAddVisibleByteAndTimestamp(ansiEscapeCode.charCodeAt(idx), direction, {
+        forceVisibleAsGlyph: true,
+        extraClassName: 'unknown-escape',
+      });
     }
   }
 
@@ -1767,13 +1814,29 @@ export class SingleTerminal {
    *   will be displayed. If the number is not in the valid ASCII range, the character might be displayed as a special glyph
    *   depending on the data processing settings.
    */
-  _maybeAddVisibleByteAndTimestamp(rxByte: number, direction: DataDirection) {
+  _maybeAddVisibleByteAndTimestamp(
+    rxByte: number,
+    direction: DataDirection,
+    options?: { forceVisibleAsGlyph?: boolean; extraClassName?: string }
+  ) {
+    // Read options via optional chaining rather than defaulting the parameter to
+    // a fresh `{}` — this is called per visible byte on the hot path and a
+    // per-char allocation would add needless GC pressure.
     const nonVisibleCharDisplayBehavior = this.rxSettings.nonVisibleCharDisplayBehavior;
 
     let char: string;
     if (rxByte >= 0x20 && rxByte <= 0x7e) {
       // Is printable ASCII character, no shifting needed
       char = String.fromCharCode(rxByte);
+    } else if (options?.forceVisibleAsGlyph) {
+      // Caller (e.g. surfacing an unknown escape sequence) wants this
+      // non-visible byte shown regardless of the swallow setting: control chars
+      // as their PUA control glyph, everything else as a hex glyph.
+      if (rxByte <= 0x7f) {
+        char = String.fromCharCode(rxByte + START_OF_CONTROL_GLYPHS);
+      } else {
+        char = String.fromCharCode(rxByte + START_OF_HEX_GLYPHS);
+      }
     } else {
       // We have either a control char or not in ASCII range (0x80 and above).
       // What we do depends on data processing setting
@@ -1835,10 +1898,10 @@ export class SingleTerminal {
       }
     }
 
-    this.addVisibleChar(char, direction);
+    this.addVisibleChar(char, direction, options?.extraClassName);
   }
 
-  addVisibleChar(char: string, direction: DataDirection) {
+  addVisibleChar(char: string, direction: DataDirection, extraClassName?: string) {
     const terminalChar = new TerminalChar();
     terminalChar.char = char;
 
@@ -1886,6 +1949,13 @@ export class SingleTerminal {
         // Bright background colors
         classList.push(`b${this.currBackgroundColorNum}`);
       }
+    }
+
+    // Extra caller-supplied class (e.g. 'unknown-escape' for surfaced escape
+    // sequences) is appended last so it can override the colour/direction
+    // classes via CSS specificity.
+    if (extraClassName !== undefined) {
+      classList.push(extraClassName);
     }
 
     terminalChar.className = classList.join(' ');

--- a/src/renderer/src/view/FakePorts/FakePortDialogView.tsx
+++ b/src/renderer/src/view/FakePorts/FakePortDialogView.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { Button, Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, List, ListItem, ListItemButton, ListItemIcon, ListItemText, TextField, Typography } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 
 import { App } from '../../model/App';
@@ -20,8 +20,21 @@ export default observer((props: Props) => {
     >
       <DialogTitle>{'Select fake port to connect to.'}</DialogTitle>
       <DialogContent>
+        <TextField
+          name="fakePortSearch"
+          label="Search fake ports"
+          variant="outlined"
+          size="small"
+          fullWidth
+          autoFocus
+          value={app.fakePortController.searchText}
+          onChange={(e) => {
+            app.fakePortController.setSearchText(e.target.value);
+          }}
+          sx={{ mt: 1, mb: 1 }}
+        />
         <List dense={true} sx={{ maxHeight: '600px', scroll: 'auto' }}>
-          {app.fakePortController.fakePorts.map((fakePort, idx) => {
+          {app.fakePortController.filteredFakePorts.map(({ fakePort, idx }) => {
             return (
               <ListItem key={idx}>
                 <ListItemButton
@@ -49,6 +62,9 @@ export default observer((props: Props) => {
               </ListItem>
             );
           })}
+          {app.fakePortController.filteredFakePorts.length === 0 && (
+            <Typography sx={{ p: 2, color: 'text.secondary' }}>No fake ports match "{app.fakePortController.searchText}".</Typography>
+          )}
         </List>
       </DialogContent>
       <DialogActions>

--- a/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
@@ -112,6 +112,29 @@ function RxSettingsView(props: Props) {
                 sx={{ marginBottom: '15px' }}
               />
             </Tooltip>
+            {/* =============================================================================== */}
+            {/* SHOW UNKNOWN ESCAPE CODES */}
+            {/* =============================================================================== */}
+            <Tooltip
+              title="If enabled, CSI escape sequences that are received but not supported by NinjaTerm (or that are malformed) are shown inline in the terminal as a highlighted marker, instead of being silently discarded. Useful for troubleshooting ANSI escape sequences. Requires ANSI escape code parsing to be enabled."
+              placement="top"
+              {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    name="showUnknownEscapeCodes"
+                    checked={rxSettings.showUnknownEscapeCodes}
+                    onChange={(e) => {
+                      rxSettings.setShowUnknownEscapeCodes(e.target.checked);
+                    }}
+                    disabled={rxSettings.dataType !== DataType.ASCII || !rxSettings.ansiEscapeCodeParsingEnabled}
+                  />
+                }
+                label="Show Unknown Escape Codes"
+                sx={{ marginBottom: '15px' }}
+              />
+            </Tooltip>
           </BorderedSection>
 
           <BorderedSection title="Echo" childStyle={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
@@ -186,5 +186,4 @@
 span.unknown-escape {
   background-color: var(--vga-bright-magenta);
   color: rgb(0, 0, 0);
-  border-radius: 2px;
 }

--- a/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
+++ b/src/renderer/src/view/Terminals/SingleTerminal/SingleTerminalView.css
@@ -176,3 +176,15 @@
   background-color: rgb(255, 152, 0); /* saturated amber */
   color: #111;
 }
+
+/* UNKNOWN / UNSUPPORTED ESCAPE SEQUENCES */
+/*================================================================*/
+/* Applied to each char of an escape sequence that was received but not
+   supported (or was malformed), when the "Show Unknown Escape Codes" setting is
+   enabled. The `span` prefix lifts the specificity above the single-class SGR
+   colour rules (.f31 etc.) so the marker styling always wins. */
+span.unknown-escape {
+  background-color: var(--vga-bright-magenta);
+  color: rgb(0, 0, 0);
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Summary

Adds support for troubleshooting ANSI escape sequences by making **unknown sequences visible** instead of silently dropping them.

A new opt-in RX setting, **"Show Unknown Escape Codes"**, renders unsupported or malformed CSI sequences (e.g. `ESC[K`, `ESC[6n`, `ESC[?25h`, unsupported SGR codes) inline in the terminal as a highlighted `unknown-escape` marker. Previously these were discarded silently (or logged only to DevTools).

## Details

- **Setting** `showUnknownEscapeCodes` (default **OFF** — behaviour unchanged until enabled), wired through `RxSettings`, `RxSettingsData`, and the settings UI (disabled unless ASCII + ANSI parsing on).
- **Parser** (`SingleTerminal`): new `_surfaceUnknownEscapeCode` helper renders the raw sequence bytes (ESC shown as its control glyph) tagged `unknown-escape`, gated by the setting. Wired into unrecognized CSI final bytes, unsupported SGR codes, and unsupported/NaN ED + cursor-move params. The hot path stays allocation-free.
- **Styling**: `span.unknown-escape` magenta highlight.
- **Migration**: folded into the existing unreleased `v20→v21` migration (no extra version bump).
- Added 4 unit tests, a CHANGELOG entry, and a CLAUDE.md note about bumping the app data version only once per release.

## Scope note

Non-CSI escapes (OSC `ESC]`, charset `ESC(`) already surface as raw glyphs via the existing max-length path and were left unchanged.

## Testing

- `npx tsc` clean
- `npm run test:unit` — functional suite passes (253 tests), including 4 new surfacing tests and the migration round-trip. The one `ansi-heavy` perf-threshold miss is an environmental/loaded-machine artifact (all scenarios, including the untouched plain-ASCII path, came in uniformly slow), not a regression.