### PR TITLE
Add in-app links to the online manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Surface unknown ANSI escape sequences.** New opt-in RX "Show Unknown Escape Codes" setting renders unsupported/malformed CSI sequences (e.g. `ESC[K`, `ESC[6n`, unsupported SGR codes) inline as a highlighted `unknown-escape` marker instead of silently dropping them, via `SingleTerminal._surfaceUnknownEscapeCode`; setting added to the v20→v21 AppData migration.
 - **Fake port "unsupported escape codes"** that streams a rotating set of CSI sequences NinjaTerm doesn't support and auto-enables "Show Unknown Escape Codes", for testing the surfacing feature.
 - **Search box in the fake port selection dialog** to filter the (now long) list by name/description.
+- **Help button in the left sidebar** that opens the online manual in the browser, plus a contextual "Open Manual" link in the RX ANSI Escape Codes settings section (deep-linked to the ANSI codes reference).
 
 ## [5.14.0] - 2026-06-12
 

--- a/src/renderer/src/view/AppView.tsx
+++ b/src/renderer/src/view/AppView.tsx
@@ -7,6 +7,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import SaveAsIcon from '@mui/icons-material/SaveAs';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import CssBaseline from '@mui/material/CssBaseline';
 import { SnackbarProvider } from 'notistack';
 
@@ -412,6 +413,28 @@ const AppView = observer(() => {
               data-testid="show-logging-pane-button"
             >
               <SaveAsIcon />
+            </IconButton>
+          </Tooltip>
+          {/* ==================================================== */}
+          {/* HELP BUTTON (opens the online manual) */}
+          {/* ==================================================== */}
+          {/* marginTop: auto pushes Help to the bottom of the sidebar, away from
+              the pane-switching buttons — it opens the external manual rather
+              than switching panes. */}
+          <Tooltip {...app.settings.displaySettings.getBasicTooltipConfig()} title="Open the NinjaTerm manual in your browser." placement="right">
+            <IconButton
+              onClick={async () => {
+                try {
+                  await window.electronAPI.shell.openExternal("https://ninjaterm.mbedded.ninja/manual");
+                } catch (error) {
+                  console.error("Failed to open manual:", error);
+                }
+              }}
+              color="primary"
+              data-testid="show-help-button"
+              sx={{ marginTop: 'auto' }}
+            >
+              <HelpOutlineIcon />
             </IconButton>
           </Tooltip>
         </div>

--- a/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
+++ b/src/renderer/src/view/Settings/RxSettings/RxSettingsView.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormLabel, InputAdornment, InputLabel, MenuItem, Radio, RadioGroup, Select, Tooltip } from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, FormLabel, InputAdornment, InputLabel, MenuItem, Radio, RadioGroup, Select, Tooltip } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 
 import RxSettings, {
@@ -134,6 +134,30 @@ function RxSettingsView(props: Props) {
                 label="Show Unknown Escape Codes"
                 sx={{ marginBottom: '15px' }}
               />
+            </Tooltip>
+            {/* =============================================================================== */}
+            {/* OPEN MANUAL (ANSI escape codes section) */}
+            {/* =============================================================================== */}
+            <Tooltip
+              title="Open the NinjaTerm manual in your browser, at the section listing all supported ANSI escape codes."
+              placement="top"
+              {...rxSettings.profileManager.app.settings.displaySettings.getBasicTooltipConfig()}
+            >
+              <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                sx={{ textTransform: 'none', alignSelf: 'start' }}
+                onClick={async () => {
+                  try {
+                    await window.electronAPI.shell.openExternal('https://ninjaterm.mbedded.ninja/manual#ansi-escape-codes');
+                  } catch (error) {
+                    console.error('Failed to open manual:', error);
+                  }
+                }}
+              >
+                Open Manual
+              </Button>
             </Tooltip>
           </BorderedSection>
 


### PR DESCRIPTION
## Summary

A first step toward integrating help into the app (someone asked about this). Rather than embedding the manual, this adds **in-app entry points to the existing online manual** — the lightweight option.

- **Help button in the left sidebar** (`HelpOutlineIcon`), pinned to the bottom (`marginTop: auto`) so it sits apart from the pane-switching buttons, since it opens externally rather than switching panes. Opens `ninjaterm.mbedded.ninja/manual`.
- **Contextual "Open Manual" link** in the RX → ANSI Escape Codes settings section, deep-linked to `…/manual#ansi-escape-codes` — pairs with the recent "Show Unknown Escape Codes" feature.

Both reuse the existing `window.electronAPI.shell.openExternal` pattern already used by the Graphing pane's "Open Manual" button — no new plumbing.

## Notes

This is the minimal "more links" approach. Fuller in-app help (rendering the bundled manual markdown natively in a Help pane, working offline) was considered but deferred. Natural follow-up spots for more contextual links: other settings sections and an About entry.

## Testing

- `npx tsc` clean
- `npm run test:unit` — 254 tests pass (UI-only change; no unit-test coverage for these views)